### PR TITLE
admin_lesson_delete_activate_disable

### DIFF
--- a/tests/Admin/Lesson/AdminLessonDeleteActivateDisableTest.php
+++ b/tests/Admin/Lesson/AdminLessonDeleteActivateDisableTest.php
@@ -1,0 +1,318 @@
+<?php
+
+namespace App\Tests\Admin\Lesson;
+
+use App\DataFixtures\TestUserFixtures;
+use App\DataFixtures\ThemeFixtures;
+use App\Entity\Lesson;
+use App\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Liip\TestFixturesBundle\Services\DatabaseToolCollection;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\DomCrawler\Crawler;
+
+class AdminLessonDeleteActivateDisableTest extends WebTestCase
+{
+    private KernelBrowser $client;
+    private EntityManagerInterface $em;
+    private $databaseTool;
+
+    protected function setUp(): void
+    {
+        self::ensureKernelShutdown();
+
+        $this->client = static::createClient();
+        $this->em = static::getContainer()->get(EntityManagerInterface::class);
+
+        $this->databaseTool = static::getContainer()
+            ->get(DatabaseToolCollection::class)
+            ->get();
+
+        $this->databaseTool->loadFixtures([
+            TestUserFixtures::class,
+            ThemeFixtures::class,
+        ]);
+    }
+
+    private function loginAsAdmin(): void
+    {
+        $admin = $this->em->getRepository(User::class)
+            ->findOneBy(['email' => TestUserFixtures::ADMIN_EMAIL]);
+
+        self::assertNotNull($admin, 'Admin fixture not found.');
+        $this->client->loginUser($admin);
+    }
+
+    private function loginAsUser(): void
+    {
+        $user = $this->em->getRepository(User::class)
+            ->findOneBy(['email' => TestUserFixtures::USER_EMAIL]);
+
+        self::assertNotNull($user, 'User fixture not found.');
+        $this->client->loginUser($user);
+    }
+
+    private function getAnyLesson(): Lesson
+    {
+        $lesson = $this->em->getRepository(Lesson::class)->findOneBy([]);
+        self::assertNotNull($lesson, 'No lesson found in fixtures.');
+        self::assertNotNull($lesson->getId(), 'Fixture lesson must have an id.');
+        return $lesson;
+    }
+
+    private function setLessonActive(Lesson $lesson, bool $active): Lesson
+    {
+        $lesson->setIsActive($active);
+        $this->em->flush();
+        $this->em->clear();
+
+        /** @var Lesson|null $reloaded */
+        $reloaded = $this->em->getRepository(Lesson::class)->find($lesson->getId());
+        self::assertNotNull($reloaded);
+
+        return $reloaded;
+    }
+
+    private function extractDisableCsrfFromDeletePage(int $lessonId): string
+    {
+        $crawler = $this->client->request('GET', sprintf('https://localhost/admin/lesson/%d/delete', $lessonId));
+        self::assertResponseIsSuccessful();
+
+        $tokenNode = $crawler->filter('input[name="_token"]');
+        self::assertGreaterThan(0, $tokenNode->count(), 'CSRF token input not found on delete page.');
+
+        $token = (string) $tokenNode->attr('value');
+        self::assertNotSame('', $token, 'CSRF token value is empty on delete page.');
+
+        return $token;
+    }
+
+    private function extractActivateCsrfFromIndexPage(int $lessonId): string
+    {
+        $crawler = $this->client->request('GET', 'https://localhost/admin/lesson');
+        self::assertResponseIsSuccessful();
+
+        // Form de restauration dans index.html.twig :
+        // <form method="post" action="/admin/lesson/{id}/activate"> <input type="hidden" name="_token" value="...">
+        $formNode = $crawler->filter(sprintf('form[action="/admin/lesson/%d/activate"]', $lessonId));
+        self::assertGreaterThan(0, $formNode->count(), 'Activate form not found on index page for this lesson.');
+
+        $tokenNode = $formNode->filter('input[name="_token"]');
+        self::assertGreaterThan(0, $tokenNode->count(), 'CSRF token input not found in activate form.');
+
+        $token = (string) $tokenNode->attr('value');
+        self::assertNotSame('', $token, 'CSRF token value is empty in activate form.');
+
+        return $token;
+    }
+
+    private function assertAnonymousRedirectsToLogin(): void
+    {
+        self::assertTrue($this->client->getResponse()->isRedirection(), 'Anonymous should be redirected.');
+        $location = (string) $this->client->getResponse()->headers->get('Location');
+        self::assertStringContainsString('/login', $location, 'Expected redirect to /login.');
+    }
+
+    // -------------------------------------------------
+    // GET /delete
+    // -------------------------------------------------
+
+    public function testDeleteConfirmGetOkAsAdmin(): void
+    {
+        $this->loginAsAdmin();
+
+        $lesson = $this->getAnyLesson();
+        $lessonId = (int) $lesson->getId();
+
+        $this->client->request('GET', sprintf('https://localhost/admin/lesson/%d/delete', $lessonId));
+        self::assertResponseIsSuccessful();
+
+        self::assertSelectorTextContains('h1', 'Archiver une leçon');
+        self::assertSelectorExists('form[action="/admin/lesson/'.$lessonId.'/disable"]');
+        self::assertSelectorExists('input[name="_token"]');
+        self::assertSelectorTextContains('button', 'Confirmer l’archivage');
+    }
+
+    public function testDeleteConfirmGetRedirectsWhenAnonymous(): void
+    {
+        $lesson = $this->getAnyLesson();
+        $lessonId = (int) $lesson->getId();
+
+        $this->client->request('GET', sprintf('https://localhost/admin/lesson/%d/delete', $lessonId));
+        $this->assertAnonymousRedirectsToLogin();
+    }
+
+    public function testDeleteConfirmGetForbiddenForRoleUser(): void
+    {
+        $this->loginAsUser();
+
+        $lesson = $this->getAnyLesson();
+        $lessonId = (int) $lesson->getId();
+
+        $this->client->request('GET', sprintf('https://localhost/admin/lesson/%d/delete', $lessonId));
+        self::assertResponseStatusCodeSame(403);
+    }
+
+    // -------------------------------------------------
+    // POST /disable
+    // -------------------------------------------------
+
+    public function testDisableSetsIsActiveFalseAndRedirectsWithValidCsrf(): void
+    {
+        $this->loginAsAdmin();
+
+        $lesson = $this->getAnyLesson();
+        $lesson = $this->setLessonActive($lesson, true);
+        $lessonId = (int) $lesson->getId();
+
+        $csrf = $this->extractDisableCsrfFromDeletePage($lessonId);
+
+        $this->client->request('POST', sprintf('https://localhost/admin/lesson/%d/disable', $lessonId), [
+            '_token' => $csrf,
+        ]);
+
+        self::assertResponseRedirects('/admin/lesson');
+        $this->client->followRedirect();
+        self::assertResponseIsSuccessful();
+
+        self::assertSelectorExists('.flash-messages .flash.flash-success');
+        self::assertSelectorTextContains('.flash-messages .flash.flash-success', 'Leçon archivée.');
+
+        $this->em->clear();
+        /** @var Lesson|null $reloaded */
+        $reloaded = $this->em->getRepository(Lesson::class)->find($lessonId);
+        self::assertNotNull($reloaded);
+        self::assertFalse($reloaded->isActive(), 'Lesson should be inactive after disable.');
+    }
+
+    public function testDisableWithInvalidCsrfReturns403AndDoesNotChange(): void
+    {
+        $this->loginAsAdmin();
+
+        $lesson = $this->getAnyLesson();
+        $lesson = $this->setLessonActive($lesson, true);
+        $lessonId = (int) $lesson->getId();
+
+        $this->client->request('POST', sprintf('https://localhost/admin/lesson/%d/disable', $lessonId), [
+            '_token' => 'invalid_token',
+        ]);
+
+        self::assertResponseStatusCodeSame(403);
+
+        $this->em->clear();
+        $reloaded = $this->em->getRepository(Lesson::class)->find($lessonId);
+        self::assertNotNull($reloaded);
+        self::assertTrue($reloaded->isActive(), 'Lesson should remain active if CSRF is invalid.');
+    }
+
+    public function testDisableRedirectsWhenAnonymous(): void
+    {
+        $lesson = $this->getAnyLesson();
+        $lessonId = (int) $lesson->getId();
+
+        $this->client->request('POST', sprintf('https://localhost/admin/lesson/%d/disable', $lessonId), [
+            '_token' => 'whatever',
+        ]);
+
+        $this->assertAnonymousRedirectsToLogin();
+    }
+
+    public function testDisableForbiddenForRoleUser(): void
+    {
+        $this->loginAsUser();
+
+        $lesson = $this->getAnyLesson();
+        $lessonId = (int) $lesson->getId();
+
+        $this->client->request('POST', sprintf('https://localhost/admin/lesson/%d/disable', $lessonId), [
+            '_token' => 'whatever',
+        ]);
+
+        self::assertResponseStatusCodeSame(403);
+    }
+
+    // -------------------------------------------------
+    // POST /activate
+    // -------------------------------------------------
+
+    public function testActivateSetsIsActiveTrueAndRedirectsWithValidCsrf(): void
+    {
+        $this->loginAsAdmin();
+
+        $lesson = $this->getAnyLesson();
+        $lesson = $this->setLessonActive($lesson, false);
+        $lessonId = (int) $lesson->getId();
+
+        // Le token est rendu dans le formulaire de restauration sur /admin/lesson
+        $csrf = $this->extractActivateCsrfFromIndexPage($lessonId);
+
+        $this->client->request('POST', sprintf('https://localhost/admin/lesson/%d/activate', $lessonId), [
+            '_token' => $csrf,
+        ]);
+
+        self::assertResponseRedirects('/admin/lesson');
+        $this->client->followRedirect();
+        self::assertResponseIsSuccessful();
+
+        self::assertSelectorExists('.flash-messages .flash.flash-success');
+        self::assertSelectorTextContains('.flash-messages .flash.flash-success', 'Leçon restaurée.');
+
+        $this->em->clear();
+        $reloaded = $this->em->getRepository(Lesson::class)->find($lessonId);
+        self::assertNotNull($reloaded);
+        self::assertTrue($reloaded->isActive(), 'Lesson should be active after activate.');
+    }
+
+    public function testActivateWithInvalidCsrfReturns403AndDoesNotChange(): void
+    {
+        $this->loginAsAdmin();
+
+        $lesson = $this->getAnyLesson();
+        $lesson = $this->setLessonActive($lesson, false);
+        $lessonId = (int) $lesson->getId();
+
+        $this->client->request('POST', sprintf('https://localhost/admin/lesson/%d/activate', $lessonId), [
+            '_token' => 'invalid_token',
+        ]);
+
+        self::assertResponseStatusCodeSame(403);
+
+        $this->em->clear();
+        $reloaded = $this->em->getRepository(Lesson::class)->find($lessonId);
+        self::assertNotNull($reloaded);
+        self::assertFalse($reloaded->isActive(), 'Lesson should remain inactive if CSRF is invalid.');
+    }
+
+    public function testActivateRedirectsWhenAnonymous(): void
+    {
+        $lesson = $this->getAnyLesson();
+        $lessonId = (int) $lesson->getId();
+
+        $this->client->request('POST', sprintf('https://localhost/admin/lesson/%d/activate', $lessonId), [
+            '_token' => 'whatever',
+        ]);
+
+        $this->assertAnonymousRedirectsToLogin();
+    }
+
+    public function testActivateForbiddenForRoleUser(): void
+    {
+        $this->loginAsUser();
+
+        $lesson = $this->getAnyLesson();
+        $lessonId = (int) $lesson->getId();
+
+        $this->client->request('POST', sprintf('https://localhost/admin/lesson/%d/activate', $lessonId), [
+            '_token' => 'whatever',
+        ]);
+
+        self::assertResponseStatusCodeSame(403);
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+        $this->em->close();
+    }
+}


### PR DESCRIPTION
Mise en place d'un test pour vérifier l'archivage,restauration et message confirmation archivage d'une leçon.
Nouveau fichier :  tests/Admin/Lesson/AdminLessonDeleteActivateDisableTest.php
On couvre:
GET /admin/lesson/{id}/delete (admin OK)
POST /admin/lesson/{id}/disable → isActive=false + redirect + flash
POST /admin/lesson/{id}/activate → isActive=true + redirect + flash
CSRF invalide sur disable/activate → 403
Accès :
anon → redirect /login
ROLE_USER → 403
ROLE_ADMIN → OK