### PR TITLE
admin_purchases_index

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -13,8 +13,6 @@
         <ini name="error_reporting" value="-1" />
         <server name="APP_ENV" value="test" force="true" />
         <server name="SHELL_VERBOSITY" value="-1" />
-        <server name="SYMFONY_PHPUNIT_REMOVE" value="" />
-        <server name="SYMFONY_PHPUNIT_VERSION" value="9.5" />
     </php>
 
     <testsuites>

--- a/src/Controller/Admin/AdminPurchaseController.php
+++ b/src/Controller/Admin/AdminPurchaseController.php
@@ -7,6 +7,7 @@ use App\Repository\PurchaseRepository;
 use App\Repository\UserRepository;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Exception\BadRequestException;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
@@ -16,6 +17,32 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 #[Route('/admin/purchases', name: 'admin_purchase_')]
 class AdminPurchaseController extends AbstractController
 {
+    private function parseDateOnlyStrict(string $raw): ?\DateTimeImmutable
+    {
+        $raw = trim($raw);
+        if ($raw === '') {
+            return null;
+        }
+
+        // Format strict YYYY-MM-DD (évite "2026-2-1", etc.)
+        if (!preg_match('/^\d{4}-\d{2}-\d{2}$/', $raw)) {
+            return null;
+        }
+
+        // "!" => reset heure à 00:00:00
+        $dt = \DateTimeImmutable::createFromFormat('!Y-m-d', $raw);
+        if (!$dt) {
+            return null;
+        }
+
+        $errors = \DateTimeImmutable::getLastErrors();
+        if (($errors['warning_count'] ?? 0) > 0 || ($errors['error_count'] ?? 0) > 0) {
+            return null;
+        }
+
+        return $dt;
+    }
+
     #[Route('', name: 'index', methods: ['GET'])]
     public function index(
         Request $request,
@@ -23,10 +50,10 @@ class AdminPurchaseController extends AbstractController
         UserRepository $userRepo,
         EntityManagerInterface $em
     ): Response {
-        // Vu qu'il y a le filtre doctrine "archived_user" comme dans AdminUserController :
+        // Permet d'afficher aussi les commandes d'utilisateurs archivés
         $filters = $em->getFilters();
         if ($filters->isEnabled('archived_user')) {
-            $filters->disable('archived_user'); // on veut pouvoir voir les commandes d’archivés
+            $filters->disable('archived_user');
         }
 
         $q = trim((string) $request->query->get('q', ''));
@@ -45,17 +72,9 @@ class AdminPurchaseController extends AbstractController
         $dateFromRaw = (string) $request->query->get('dateFrom', '');
         $dateToRaw   = (string) $request->query->get('dateTo', '');
 
-        $dateFrom = null;
-        if ($dateFromRaw !== '') {
-            $dt = \DateTimeImmutable::createFromFormat('Y-m-d', $dateFromRaw);
-            $dateFrom = $dt ?: null;
-        }
-
-        $dateTo = null;
-        if ($dateToRaw !== '') {
-            $dt = \DateTimeImmutable::createFromFormat('Y-m-d', $dateToRaw);
-            $dateTo = $dt ?: null;
-        }
+        // parsing strict : invalide => null (donc filtre ignoré)
+        $dateFrom = $this->parseDateOnlyStrict($dateFromRaw);
+        $dateTo   = $this->parseDateOnlyStrict($dateToRaw);
 
         $sort = (string) $request->query->get('sort', 'createdAt'); // createdAt|status|total|paidAt|user
         if (!in_array($sort, ['createdAt', 'status', 'total', 'paidAt', 'user'], true)) {
@@ -80,8 +99,8 @@ class AdminPurchaseController extends AbstractController
             $perPage
         );
 
-        // Optionnel : alimenter un select user (si tu veux)
-        $users = $userRepo->findActiveUsers(); // tu as déjà cette méthode
+        // Liste des users pour le select
+        $users = $userRepo->findActiveUsers();
 
         return $this->render('admin/purchases/index.html.twig', [
             'purchases' => $result['items'],
@@ -97,8 +116,9 @@ class AdminPurchaseController extends AbstractController
             'userId' => $userId,
             'users' => $users,
 
-            'dateFrom' => $dateFromRaw,
-            'dateTo' => $dateToRaw,
+            //  valeur HTML propre (si invalide => '')
+            'dateFrom' => $dateFrom ? $dateFrom->format('Y-m-d') : '',
+            'dateTo'   => $dateTo ? $dateTo->format('Y-m-d') : '',
 
             'sort' => $sort,
             'dir' => $dir,

--- a/src/Repository/PurchaseRepository.php
+++ b/src/Repository/PurchaseRepository.php
@@ -5,7 +5,6 @@ namespace App\Repository;
 use App\Entity\Purchase;
 use App\Entity\User;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
-use Doctrine\ORM\Tools\Pagination\Paginator;
 use Doctrine\Persistence\ManagerRegistry;
 
 class PurchaseRepository extends ServiceEntityRepository
@@ -79,7 +78,10 @@ class PurchaseRepository extends ServiceEntityRepository
     }
 
     /**
-     * @return array{items: Purchase[], total: int}
+     * @return array{items: array<int, array{purchase: Purchase, itemsCount: int}>, total: int}
+     * on normalise les données avant de construire les clauses WHERE pour éviter les problèmes
+     * de jointures et de group by, et on ne refait pas la requête pour chaque filtre, 
+     * on construit une seule requête avec tous les filtres appliqués
      */
     public function findForAdminListPaginated(
         string $q,
@@ -92,12 +94,26 @@ class PurchaseRepository extends ServiceEntityRepository
         int $page,
         int $perPage
     ): array {
+        //  Normalisation "date only"
+        // dateFrom => début de journée
+        // dateTo   => fin de journée
+        if ($dateFrom) {
+            $dateFrom = $dateFrom->setTime(0, 0, 0);
+        }
+        if ($dateTo) {
+            $dateTo = $dateTo->setTime(23, 59, 59);
+        }
+
         $qb = $this->createQueryBuilder('p')
-            ->leftJoin('p.user', 'u')->addSelect('u');
+            ->leftJoin('p.user', 'u')->addSelect('u')
+            ->leftJoin('p.items', 'pi')
+            ->addSelect('COUNT(pi.id) AS itemsCount')
+            ->groupBy('p.id')
+            ->addGroupBy('u.id');
 
         if ($q !== '') {
             $qb->andWhere('LOWER(p.orderNumber) LIKE :q OR LOWER(u.email) LIKE :q OR LOWER(u.firstName) LIKE :q OR LOWER(u.lastName) LIKE :q')
-               ->setParameter('q', '%'.mb_strtolower($q).'%');
+                ->setParameter('q', '%'.mb_strtolower($q).'%');
         }
 
         if ($status !== null && $status !== '' && $status !== 'all') {
@@ -112,7 +128,7 @@ class PurchaseRepository extends ServiceEntityRepository
             $qb->andWhere('p.createdAt >= :from')->setParameter('from', $dateFrom);
         }
         if ($dateTo) {
-            $qb->andWhere('p.createdAt <= :to')->setParameter('to', $dateTo->setTime(23, 59, 59));
+            $qb->andWhere('p.createdAt <= :to')->setParameter('to', $dateTo);
         }
 
         $dir = strtoupper($dir) === 'ASC' ? 'ASC' : 'DESC';
@@ -126,16 +142,53 @@ class PurchaseRepository extends ServiceEntityRepository
         ];
         $sortExpr = $allowedSort[$sort] ?? 'p.createdAt';
 
-        $qb->orderBy($sortExpr, $dir)
-           ->addOrderBy('p.id', $dir)
-           ->setFirstResult(($page - 1) * $perPage)
-           ->setMaxResults($perPage);
+        // 1) Total (requête séparée, sans groupBy / limit / offset)
+        $countQb = $this->createQueryBuilder('p')
+            ->select('COUNT(DISTINCT p.id)')
+            ->leftJoin('p.user', 'u');
 
-        $paginator = new Paginator($qb->getQuery(), true);
+        if ($q !== '') {
+            $countQb->andWhere('LOWER(p.orderNumber) LIKE :q OR LOWER(u.email) LIKE :q OR LOWER(u.firstName) LIKE :q OR LOWER(u.lastName) LIKE :q')
+                ->setParameter('q', '%'.mb_strtolower($q).'%');
+        }
+        if ($status !== null && $status !== '' && $status !== 'all') {
+            $countQb->andWhere('p.status = :status')->setParameter('status', $status);
+        }
+        if ($userId) {
+            $countQb->andWhere('u.id = :uid')->setParameter('uid', $userId);
+        }
+        if ($dateFrom) {
+            $countQb->andWhere('p.createdAt >= :from')->setParameter('from', $dateFrom);
+        }
+        if ($dateTo) {
+            $countQb->andWhere('p.createdAt <= :to')->setParameter('to', $dateTo);
+        }
+
+        $total = (int) $countQb->getQuery()->getSingleScalarResult();
+
+        // 2) Page courante
+        $qb->orderBy($sortExpr, $dir)
+            ->addOrderBy('p.id', $dir)
+            ->setFirstResult(($page - 1) * $perPage)
+            ->setMaxResults($perPage);
+
+        $rows = $qb->getQuery()->getResult();
+
+        $items = [];
+        foreach ($rows as $row) {
+            /** @var Purchase $purchase */
+            $purchase = $row[0];
+            $itemsCount = (int) ($row['itemsCount'] ?? 0);
+
+            $items[] = [
+                'purchase' => $purchase,
+                'itemsCount' => $itemsCount,
+            ];
+        }
 
         return [
-            'items' => iterator_to_array($paginator->getIterator(), false),
-            'total' => count($paginator),
+            'items' => $items,
+            'total' => $total,
         ];
     }
 

--- a/templates/admin/purchases/index.html.twig
+++ b/templates/admin/purchases/index.html.twig
@@ -136,7 +136,10 @@
                   </td>
                 </tr>
               {% else %}
-                {% for p in purchases %}
+                {# purchases = array de rows: { purchase: Purchase, itemsCount: int } #}
+                {% for row in purchases %}
+                  {% set p = row.purchase %}
+
                   {% set badgeClass =
                     p.isPaid ? 'bg-success' :
                     (p.isPending ? 'bg-warning text-dark' :
@@ -181,7 +184,7 @@
                     </td>
 
                     <td class="text-center">
-                      {{ p.items ? p.items|length : 0 }}
+                      {{ row.itemsCount }}
                     </td>
 
                     <td class="text-end">

--- a/tests/Admin/Purchases/AdminPurchasesIndexTest.php
+++ b/tests/Admin/Purchases/AdminPurchasesIndexTest.php
@@ -1,0 +1,353 @@
+<?php
+
+namespace App\Tests\Admin\Purchases;
+
+use App\DataFixtures\TestUserFixtures;
+use App\DataFixtures\ThemeFixtures;
+use App\Entity\Purchase;
+use App\Entity\PurchaseItem;
+use App\Entity\User;
+use Doctrine\DBAL\Connection;
+use Doctrine\ORM\EntityManagerInterface;
+use Liip\TestFixturesBundle\Services\DatabaseToolCollection;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+class AdminPurchasesIndexTest extends WebTestCase
+{
+    private KernelBrowser $client;
+    private EntityManagerInterface $em;
+    private Connection $db;
+
+    protected function setUp(): void
+    {
+        self::ensureKernelShutdown();
+        $this->client = static::createClient();
+        $this->client->followRedirects();
+
+        $this->em = static::getContainer()->get(EntityManagerInterface::class);
+        $this->db = $this->em->getConnection();
+
+        /** @var DatabaseToolCollection $dbTools */
+        $dbTools = static::getContainer()->get(DatabaseToolCollection::class);
+
+        // Recharge DB test + fixtures de base
+        $dbTools->get()->loadFixtures([
+            TestUserFixtures::class,
+            ThemeFixtures::class,
+        ]);
+    }
+
+    private function loginAsAdminFromFixtures(): User
+    {
+        $admin = $this->em->getRepository(User::class)->findOneBy(['email' => TestUserFixtures::ADMIN_EMAIL]);
+        self::assertNotNull($admin, 'Admin fixture introuvable.');
+
+        $this->client->loginUser($admin);
+
+        return $admin;
+    }
+
+    private function createUser(
+        string $email,
+        string $first,
+        string $last,
+        ?\DateTimeImmutable $archivedAt = null
+    ): User {
+        $u = (new User())
+            ->setEmail($email)
+            ->setFirstName($first)
+            ->setLastName($last)
+            ->setIsVerified(true)
+            ->setStoredRoles([])
+            ->setPassword('hash')
+            ->setArchivedAt($archivedAt);
+
+        $this->em->persist($u);
+        $this->em->flush();
+
+        return $u;
+    }
+
+    /**
+     * Création robuste : on persiste, puis on force createdAt + orderNumber en base (SQLite)
+     * pour éviter les surprises Doctrine/SQLite quand on veut tester des bornes de date.
+     */
+    private function createPurchase(
+        User $user,
+        string $status,
+        \DateTimeImmutable $createdAt,
+        ?\DateTimeImmutable $paidAt,
+        float $total,
+        string $orderNumber
+    ): Purchase {
+        $p = new Purchase();
+        $p->setUser($user);
+        $p->setStatus($status);
+
+        // total via item + calculateTotal()
+        $item = new PurchaseItem();
+        $item->setQuantity(1);
+        $item->setUnitPrice($total);
+        $p->addItem($item);
+        $p->calculateTotal();
+
+        if ($paidAt !== null) {
+            $p->setPaidAt($paidAt);
+        }
+
+        $this->em->persist($p);
+        $this->em->flush();
+
+        // force en DB
+        $this->db->executeStatement(
+            'UPDATE purchase SET created_at = :createdAt, order_number = :orderNumber WHERE id = :id',
+            [
+                'createdAt'   => $createdAt->format('Y-m-d H:i:s'),
+                'orderNumber' => $orderNumber,
+                'id'          => $p->getId(),
+            ]
+        );
+
+        $this->em->refresh($p);
+
+        return $p;
+    }
+
+    private function assertOrderAppearsInThisOrder(string $html, array $needlesInOrder): void
+    {
+        $pos = -1;
+        foreach ($needlesInOrder as $needle) {
+            $p = mb_strpos($html, $needle);
+            self::assertNotFalse($p, sprintf('Chaîne "%s" introuvable dans la page.', $needle));
+            self::assertTrue($p > $pos, sprintf('Ordre incorrect: "%s" apparaît trop tôt.', $needle));
+            $pos = $p;
+        }
+    }
+
+    public function testAccesPage1SansFiltre(): void
+    {
+        $this->loginAsAdminFromFixtures();
+
+        $this->client->request('GET', '/admin/purchases');
+        self::assertResponseIsSuccessful();
+
+        $html = (string) $this->client->getResponse()->getContent();
+        self::assertStringContainsString('Commandes', $html);
+    }
+
+    public function testPaginationPage1DernierePageEtPageTropGrandeListeVideSansCrash(): void
+    {
+        $this->loginAsAdminFromFixtures();
+
+        $u = $this->em->getRepository(User::class)->findOneBy(['email' => TestUserFixtures::USER_EMAIL]);
+        self::assertNotNull($u);
+
+        // 45 => 3 pages si perPage=20
+        for ($i = 1; $i <= 45; $i++) {
+            $this->createPurchase(
+                $u,
+                Purchase::STATUS_PAID,
+                new \DateTimeImmutable('2026-01-01 10:00:00'),
+                new \DateTimeImmutable('2026-01-01 10:05:00'),
+                (float) $i,
+                sprintf('ORD-PAG-%03d', $i)
+            );
+        }
+
+        $this->client->request('GET', '/admin/purchases?page=1');
+        self::assertResponseIsSuccessful();
+        self::assertStringNotContainsString('Aucune commande trouvée', (string) $this->client->getResponse()->getContent());
+
+        $this->client->request('GET', '/admin/purchases?page=3');
+        self::assertResponseIsSuccessful();
+        self::assertStringNotContainsString('Aucune commande trouvée', (string) $this->client->getResponse()->getContent());
+
+        $this->client->request('GET', '/admin/purchases?page=999');
+        self::assertResponseIsSuccessful();
+        self::assertStringContainsString('Aucune commande trouvée', (string) $this->client->getResponse()->getContent());
+    }
+
+    public function testFiltreQMatchOrderNumberEmailPrenomNomLowercase(): void
+    {
+        $this->loginAsAdminFromFixtures();
+
+        $u = $this->createUser('alpha@example.com', 'Jean', 'Dupont');
+        $this->createPurchase(
+            $u,
+            Purchase::STATUS_PENDING,
+            new \DateTimeImmutable('2026-02-01 09:00:00'),
+            null,
+            99.99,
+            'ORD-SEARCH-XYZ'
+        );
+
+        $this->client->request('GET', '/admin/purchases?q=ord-search-xyz');
+        self::assertResponseIsSuccessful();
+        self::assertStringContainsString('ORD-SEARCH-XYZ', (string) $this->client->getResponse()->getContent());
+
+        $this->client->request('GET', '/admin/purchases?q=alpha@example.com');
+        self::assertResponseIsSuccessful();
+        self::assertStringContainsString('ORD-SEARCH-XYZ', (string) $this->client->getResponse()->getContent());
+
+        $this->client->request('GET', '/admin/purchases?q=jean');
+        self::assertResponseIsSuccessful();
+        self::assertStringContainsString('ORD-SEARCH-XYZ', (string) $this->client->getResponse()->getContent());
+
+        $this->client->request('GET', '/admin/purchases?q=dupont');
+        self::assertResponseIsSuccessful();
+        self::assertStringContainsString('ORD-SEARCH-XYZ', (string) $this->client->getResponse()->getContent());
+    }
+
+    public function testFiltreStatusValeurAutoriseeEtValeurInterditeFallbackAll(): void
+    {
+        $this->loginAsAdminFromFixtures();
+
+        $u = $this->createUser('buyer2@test.com', 'Alice', 'Martin');
+        $this->createPurchase($u, Purchase::STATUS_PAID, new \DateTimeImmutable('2026-01-10 10:00:00'), new \DateTimeImmutable('2026-01-10 10:10:00'), 10, 'ORD-ST-PAID');
+        $this->createPurchase($u, Purchase::STATUS_CART, new \DateTimeImmutable('2026-01-11 10:00:00'), null, 20, 'ORD-ST-CART');
+
+        $this->client->request('GET', '/admin/purchases?status=paid');
+        self::assertResponseIsSuccessful();
+        $html = (string) $this->client->getResponse()->getContent();
+        self::assertStringContainsString('ORD-ST-PAID', $html);
+        self::assertStringNotContainsString('ORD-ST-CART', $html);
+
+        // valeur interdite => doit afficher all
+        $this->client->request('GET', '/admin/purchases?status=hack');
+        self::assertResponseIsSuccessful();
+        $html = (string) $this->client->getResponse()->getContent();
+        self::assertStringContainsString('ORD-ST-PAID', $html);
+        self::assertStringContainsString('ORD-ST-CART', $html);
+    }
+
+    public function testFiltreUserLimiteAUnUser(): void
+    {
+        $this->loginAsAdminFromFixtures();
+
+        $u1 = $this->createUser('u1@test.com', 'Bob', 'Alpha');
+        $u2 = $this->createUser('u2@test.com', 'Carl', 'Beta');
+
+        $this->createPurchase($u1, Purchase::STATUS_PAID, new \DateTimeImmutable('2026-01-01 10:00:00'), new \DateTimeImmutable('2026-01-01 10:05:00'), 15, 'ORD-U1');
+        $this->createPurchase($u2, Purchase::STATUS_PAID, new \DateTimeImmutable('2026-01-01 11:00:00'), new \DateTimeImmutable('2026-01-01 11:05:00'), 25, 'ORD-U2');
+
+        $this->client->request('GET', '/admin/purchases?user=' . $u1->getId());
+        self::assertResponseIsSuccessful();
+
+        $html = (string) $this->client->getResponse()->getContent();
+        self::assertStringContainsString('ORD-U1', $html);
+        self::assertStringNotContainsString('ORD-U2', $html);
+    }
+
+    public function testFiltreDatesDateFromSeulDateToSeulInclutFinJourneeFromGreaterThanToInvalideIgnoree(): void
+    {
+        $this->loginAsAdminFromFixtures();
+
+        $u = $this->createUser('dates@test.com', 'Dora', 'Dates');
+
+        $this->createPurchase($u, Purchase::STATUS_PAID, new \DateTimeImmutable('2026-02-10 12:00:00'), new \DateTimeImmutable('2026-02-10 12:30:00'), 10, 'ORD-D-10');
+        $this->createPurchase($u, Purchase::STATUS_PAID, new \DateTimeImmutable('2026-02-20 00:00:01'), new \DateTimeImmutable('2026-02-20 00:10:00'), 20, 'ORD-D-20-A');
+        $this->createPurchase($u, Purchase::STATUS_PAID, new \DateTimeImmutable('2026-02-20 23:59:59'), new \DateTimeImmutable('2026-02-21 00:05:00'), 30, 'ORD-D-20-B');
+
+        // dateFrom seul => doit garder 20-A et 20-B
+        $this->client->request('GET', '/admin/purchases?dateFrom=2026-02-20');
+        self::assertResponseIsSuccessful();
+        $html = (string) $this->client->getResponse()->getContent();
+        self::assertStringNotContainsString('ORD-D-10', $html);
+        self::assertStringContainsString('ORD-D-20-A', $html);
+        self::assertStringContainsString('ORD-D-20-B', $html);
+
+        // dateTo seul => doit inclure fin de journée
+        $this->client->request('GET', '/admin/purchases?dateTo=2026-02-20');
+        self::assertResponseIsSuccessful();
+        $html = (string) $this->client->getResponse()->getContent();
+        self::assertStringContainsString('ORD-D-10', $html);
+        self::assertStringContainsString('ORD-D-20-A', $html);
+        self::assertStringContainsString('ORD-D-20-B', $html);
+
+        // from > to => liste vide
+        $this->client->request('GET', '/admin/purchases?dateFrom=2026-02-21&dateTo=2026-02-20');
+        self::assertResponseIsSuccessful();
+        self::assertStringContainsString('Aucune commande trouvée', (string) $this->client->getResponse()->getContent());
+
+        // date invalide => ignorée => tout ressort
+        $this->client->request('GET', '/admin/purchases?dateFrom=2026-99-99');
+        self::assertResponseIsSuccessful();
+        $html = (string) $this->client->getResponse()->getContent();
+        self::assertStringContainsString('ORD-D-10', $html);
+        self::assertStringContainsString('ORD-D-20-A', $html);
+        self::assertStringContainsString('ORD-D-20-B', $html);
+    }
+
+    public function testTriTotalAscDescPaidAtNullsEtUserSurLastName(): void
+    {
+        $this->loginAsAdminFromFixtures();
+
+        $uA = $this->createUser('a@test.com', 'A', 'Alpha');
+        $uZ = $this->createUser('z@test.com', 'Z', 'Zulu');
+
+        $this->createPurchase($uA, Purchase::STATUS_PAID, new \DateTimeImmutable('2026-01-01 10:00:00'), new \DateTimeImmutable('2026-01-01 10:10:00'), 10, 'ORD-T-10');
+        $this->createPurchase($uA, Purchase::STATUS_PAID, new \DateTimeImmutable('2026-01-01 11:00:00'), new \DateTimeImmutable('2026-01-01 11:10:00'), 30, 'ORD-T-30');
+        $this->createPurchase($uA, Purchase::STATUS_PAID, new \DateTimeImmutable('2026-01-01 12:00:00'), new \DateTimeImmutable('2026-01-01 12:10:00'), 20, 'ORD-T-20');
+
+        $this->createPurchase($uZ, Purchase::STATUS_PENDING, new \DateTimeImmutable('2026-01-02 10:00:00'), null, 5, 'ORD-PNULL');
+        $this->createPurchase($uZ, Purchase::STATUS_PAID, new \DateTimeImmutable('2026-01-02 11:00:00'), new \DateTimeImmutable('2026-01-03 08:00:00'), 6, 'ORD-PSET');
+
+        $this->client->request('GET', '/admin/purchases?sort=total&dir=ASC');
+        self::assertResponseIsSuccessful();
+        $html = (string) $this->client->getResponse()->getContent();
+        $this->assertOrderAppearsInThisOrder($html, ['ORD-PNULL', 'ORD-PSET', 'ORD-T-10']);
+
+        $this->client->request('GET', '/admin/purchases?sort=total&dir=DESC');
+        self::assertResponseIsSuccessful();
+        $html = (string) $this->client->getResponse()->getContent();
+        $this->assertOrderAppearsInThisOrder($html, ['ORD-T-30', 'ORD-T-10']);
+
+        $this->client->request('GET', '/admin/purchases?sort=paidAt&dir=ASC');
+        self::assertResponseIsSuccessful();
+        $html = (string) $this->client->getResponse()->getContent();
+        $this->assertOrderAppearsInThisOrder($html, ['ORD-PNULL', 'ORD-PSET']);
+
+        $this->client->request('GET', '/admin/purchases?sort=user&dir=ASC');
+        self::assertResponseIsSuccessful();
+        $html = (string) $this->client->getResponse()->getContent();
+        $this->assertOrderAppearsInThisOrder($html, ['Alpha', 'Zulu']);
+    }
+
+    public function testCommandesUtilisateursArchivesApparaissentBienFiltreArchivedUserDesactiveDansIndex(): void
+    {
+        $this->loginAsAdminFromFixtures();
+
+        $archivedUser = $this->createUser(
+            'archived@test.com',
+            'Old',
+            'Archived',
+            new \DateTimeImmutable('2025-01-01 00:00:00')
+        );
+
+        $this->createPurchase(
+            $archivedUser,
+            Purchase::STATUS_PAID,
+            new \DateTimeImmutable('2026-01-05 10:00:00'),
+            new \DateTimeImmutable('2026-01-05 10:05:00'),
+            12,
+            'ORD-ARCH-1'
+        );
+
+        // Active le filtre si dispo (le controller doit le désactiver pour l’index admin)
+        $filters = $this->em->getFilters();
+        try {
+            if (!$filters->isEnabled('archived_user')) {
+                $filters->enable('archived_user');
+            }
+        } catch (\Throwable $e) {
+            self::markTestSkipped('Doctrine filter "archived_user" indisponible en env test.');
+        }
+
+        $this->client->request('GET', '/admin/purchases');
+        self::assertResponseIsSuccessful();
+
+        $html = (string) $this->client->getResponse()->getContent();
+        self::assertStringContainsString('ORD-ARCH-1', $html);
+    }
+}

--- a/tests/Repository/PurchaseRepositoryTest.php
+++ b/tests/Repository/PurchaseRepositoryTest.php
@@ -4,6 +4,7 @@ namespace App\Tests\Repository;
 
 use App\DataFixtures\TestUserFixtures;
 use App\Entity\Purchase;
+use App\Entity\PurchaseItem;
 use App\Entity\User;
 use App\Repository\PurchaseRepository;
 use Doctrine\ORM\EntityManagerInterface;
@@ -44,14 +45,6 @@ class PurchaseRepositoryTest extends KernelTestCase
         return $user;
     }
 
-    private function forceTotal(Purchase $purchase, string $total): void
-    {
-        $ref = new \ReflectionClass($purchase);
-        $prop = $ref->getProperty('total');
-        $prop->setAccessible(true);
-        $prop->setValue($purchase, $total);
-    }
-
     private function forceCreatedAt(Purchase $purchase, \DateTimeImmutable $dt): void
     {
         $ref = new \ReflectionClass($purchase);
@@ -60,6 +53,10 @@ class PurchaseRepositoryTest extends KernelTestCase
         $prop->setValue($purchase, $dt);
     }
 
+    /**
+     * Crée une commande + 1 item (pour que itemsCount fonctionne dans la requête admin).
+     * Le total est calculé via calculateTotal().
+     */
     private function createPurchase(User $user, string $status, string $total = '0.00'): Purchase
     {
         $p = new Purchase();
@@ -72,10 +69,18 @@ class PurchaseRepositoryTest extends KernelTestCase
         // En prod c’est PrePersist, mais en test on le déclenche
         $p->generateOrderNumber();
 
-        // total est une string (decimal), on force si on veut des valeurs propres
-        $this->forceTotal($p, $total);
+        // Ajoute 1 item pour que COUNT(pi.id) soit cohérent
+        $item = new PurchaseItem();
+        $item->setQuantity(1);
+        $item->setUnitPrice((float) $total);
+        $p->addItem($item);
+
+        // Total en base = somme des items
+        $p->calculateTotal();
 
         $this->em->persist($p);
+        // cascade persist sur items => pas besoin de persist($item)
+
         return $p;
     }
 
@@ -186,8 +191,8 @@ class PurchaseRepositoryTest extends KernelTestCase
             q: '',
             status: Purchase::STATUS_PAID,
             userId: $user->getId(),
-            dateFrom: new \DateTimeImmutable('2026-02-01 00:00:00'),
-            dateTo: new \DateTimeImmutable('2026-02-28 00:00:00'),
+            dateFrom: new \DateTimeImmutable('2026-02-01'),
+            dateTo: new \DateTimeImmutable('2026-02-28'),
             sort: 'createdAt',
             dir: 'DESC',
             page: 1,
@@ -197,10 +202,20 @@ class PurchaseRepositoryTest extends KernelTestCase
         self::assertArrayHasKey('items', $result);
         self::assertArrayHasKey('total', $result);
 
+        // 2 commandes paid
         self::assertSame(2, $result['total']);
         self::assertCount(2, $result['items']);
-        self::assertSame(Purchase::STATUS_PAID, $result['items'][0]->getStatus());
-        self::assertSame(Purchase::STATUS_PAID, $result['items'][1]->getStatus());
+
+        // items = rows [{purchase, itemsCount}]
+        self::assertArrayHasKey('purchase', $result['items'][0]);
+        self::assertArrayHasKey('itemsCount', $result['items'][0]);
+
+        self::assertSame(Purchase::STATUS_PAID, $result['items'][0]['purchase']->getStatus());
+        self::assertSame(Purchase::STATUS_PAID, $result['items'][1]['purchase']->getStatus());
+
+        // On a créé 1 item par purchase => itemsCount = 1
+        self::assertSame(1, $result['items'][0]['itemsCount']);
+        self::assertSame(1, $result['items'][1]['itemsCount']);
     }
 
     public function testFindOneForAdminShowLoadsUserAndItemsJoins(): void
@@ -217,8 +232,9 @@ class PurchaseRepositoryTest extends KernelTestCase
         self::assertNotNull($loaded->getUser());
         self::assertSame($user->getId(), $loaded->getUser()->getId());
 
-        // items peuvent être vides ici, mais la jointure doit fonctionner
+        // ici on a créé 1 item => on peut le tester
         self::assertNotNull($loaded->getItems());
+        self::assertCount(1, $loaded->getItems());
     }
 
     protected function tearDown(): void


### PR DESCRIPTION
réinstallation de liip/test-fixtures-bundle & de dump-autoload
Mise à jour de PurchaseRepository et AdminPurchaseController: par rapport au filtre/dates
Mise à jour du : tests/Repository/PurchaseRepositoryTest.php
Mise en place du test pour la liste des commandes pour l'administrateur, avec les filtres/tri des commandes, pagination etc.
Nouveau fichier :tests/Admin/Purchases/AdminPurchasesIndexTest.php et il fonctionne ainsi que le reste des tests.