### PR TITLE
admin_certification_download

### DIFF
--- a/src/Service/LessonValidatedService.php
+++ b/src/Service/LessonValidatedService.php
@@ -84,7 +84,7 @@ class LessonValidatedService
         $validatedIds = array_map(fn($lv) => $lv->getLesson()->getId(), $validatedLessons);
 
         foreach ($lessons as $lesson) {
-            if (!in_array($lesson->getId(), $validatedIds)) {
+            if (!in_array($lesson->getId(), $validatedIds, true)) {
                 return false;
             }
         }
@@ -119,7 +119,7 @@ class LessonValidatedService
              ->setLesson($lesson)
              ->setType('lesson')
              ->setCertificateCode(uniqid('KL-'))
-             ->setIssuedAt(new \DateTime());
+             ->setIssuedAt(new \DateTimeImmutable()); 
 
         $this->em->persist($cert);
         $this->em->flush();
@@ -145,7 +145,7 @@ class LessonValidatedService
              ->setCursus($cursus)
              ->setType('cursus')
              ->setCertificateCode(uniqid('KL-'))
-             ->setIssuedAt(new \DateTime());
+             ->setIssuedAt(new \DateTimeImmutable()); 
 
         $this->em->persist($cert);
         $this->em->flush();
@@ -172,7 +172,7 @@ class LessonValidatedService
              ->setCursus($cursus)
              ->setType('theme')
              ->setCertificateCode(uniqid('KL-'))
-             ->setIssuedAt(new \DateTime());
+             ->setIssuedAt(new \DateTimeImmutable());
 
         $this->em->persist($cert);
         $this->em->flush();

--- a/tests/Admin/Certification/AdminCertificationDownloadTest.php
+++ b/tests/Admin/Certification/AdminCertificationDownloadTest.php
@@ -1,0 +1,204 @@
+<?php
+
+namespace Tests\Admin\Certification;
+
+use App\Entity\Certification;
+use App\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
+use Twig\Environment;
+
+class AdminCertificationDownloadTest extends WebTestCase
+{
+    public function testDownloadHappyPathReturnsPdfWithProperHeadersFilenameSanitizedAndA4Landscape(): void
+    {
+        $client = static::createClient();
+
+        $admin = $this->createUser(
+            email: 'admin_download_test@example.com',
+            roles: ['ROLE_ADMIN']
+        );
+        $client->loginUser($admin);
+
+        $owner = $this->createUser(
+            email: 'cert_owner@example.com',
+            roles: []
+        );
+
+        $rawCode = 'ABC 12/34:é+%#@!"<>|\\';
+        $expectedSanitized = preg_replace('/[^A-Za-z0-9_-]/', '-', $rawCode);
+
+        $cert = $this->createCertification(
+            user: $owner,
+            certificateCode: $rawCode,
+            type: 'lesson'
+        );
+
+        $client->request(
+            'GET',
+            sprintf('/admin/certifications/%d/download', $cert->getId()),
+            server: ['HTTPS' => 'on']
+        );
+
+        $response = $client->getResponse();
+        self::assertResponseIsSuccessful();
+
+        self::assertTrue(
+            $response->headers->contains('Content-Type', 'application/pdf'),
+            'Content-Type doit être application/pdf'
+        );
+
+        $disposition = (string) $response->headers->get('Content-Disposition');
+        self::assertStringContainsString('attachment;', $disposition);
+        self::assertStringContainsString('filename="certificat-' . $expectedSanitized . '.pdf"', $disposition);
+
+        $content = $response->getContent();
+        self::assertIsString($content);
+        self::assertStringStartsWith('%PDF', $content, 'Le contenu doit ressembler à un PDF.');
+
+        $looksLikeA4Landscape =
+            (bool) preg_match(
+                '/\/MediaBox\s*\[\s*0(?:\.\d+)?\s+0(?:\.\d+)?\s+(84[01-2](?:\.\d+)?)\s+(59[45-6](?:\.\d+)?)\s*\]/',
+                $content
+            );
+
+        self::assertTrue(
+            $looksLikeA4Landscape,
+            'Le PDF devrait contenir une MediaBox proche de A4 landscape (≈ 842 x 595).'
+        );
+    }
+
+    public function testDownloadUnknownIdReturns404WithMessage(): void
+    {
+        $client = static::createClient();
+
+        $admin = $this->createUser(
+            email: 'admin_404_test@example.com',
+            roles: ['ROLE_ADMIN']
+        );
+        $client->loginUser($admin);
+
+        $client->request('GET', '/admin/certifications/99999999/download', server: ['HTTPS' => 'on']);
+
+        self::assertResponseStatusCodeSame(404);
+
+        $content = $client->getResponse()->getContent() ?? '';
+        self::assertStringContainsString('Certification introuvable', $content);
+    }
+
+    public function testTwigTemplateAutoescapePreventsHtmlInjectionFromCertificateCodeAndType(): void
+    {
+        static::createClient(); // boot kernel une fois ici
+
+        /** @var Environment $twig */
+        $twig = static::getContainer()->get(Environment::class);
+
+        $user = $this->createUser(
+            email: 'twig_escape_user@example.com',
+            roles: []
+        );
+
+        $payload = '<img src="http://example.com/evil.png" onerror="alert(1)"><b>bold</b>';
+
+        $cert = new Certification();
+        $cert->setUser($user);
+        $cert->setIssuedAt(new \DateTimeImmutable());
+        $cert->setType($payload);
+        $cert->setCertificateCode($payload);
+
+        $html = $twig->render('user/certification_pdf.html.twig', [
+            'cert' => $cert,
+        ]);
+
+        self::assertStringContainsString('&lt;img', $html);
+        self::assertStringContainsString('&lt;b&gt;bold&lt;/b&gt;', $html);
+
+        self::assertStringNotContainsString('<img', $html);
+        self::assertStringNotContainsString('<b>bold</b>', $html);
+    }
+
+    public function testDownloadWhenNotLoggedInRedirectsToLogin(): void
+    {
+        $client = static::createClient();
+
+        $client->request('GET', '/admin/certifications/1/download', server: ['HTTPS' => 'on']);
+
+        self::assertTrue($client->getResponse()->isRedirection());
+
+        $location = (string) $client->getResponse()->headers->get('Location');
+        self::assertStringContainsString('/login', $location);
+    }
+
+    public function testDownloadWhenLoggedInAsUserIsForbidden(): void
+    {
+        $client = static::createClient();
+
+        $user = $this->createUser(
+            email: 'normal_user_download_forbidden@example.com',
+            roles: []
+        );
+        $client->loginUser($user);
+
+        $owner = $this->createUser(email: 'cert_owner_forbidden@example.com', roles: []);
+        $cert = $this->createCertification(
+            user: $owner,
+            certificateCode: 'CODE-OK',
+            type: 'lesson'
+        );
+
+        $client->request(
+            'GET',
+            sprintf('/admin/certifications/%d/download', $cert->getId()),
+            server: ['HTTPS' => 'on']
+        );
+
+        self::assertResponseStatusCodeSame(403);
+    }
+
+    // -----------------------
+    // Helpers
+    // -----------------------
+
+    private function em(): EntityManagerInterface
+    {
+        /** @var EntityManagerInterface $em */
+        $em = static::getContainer()->get('doctrine')->getManager();
+        return $em;
+    }
+
+    private function createUser(string $email, array $roles): User
+    {
+        /** @var UserPasswordHasherInterface $hasher */
+        $hasher = static::getContainer()->get(UserPasswordHasherInterface::class);
+
+        $user = new User();
+        $user->setEmail($email);
+        $user->setFirstName('Test');
+        $user->setLastName('User');
+        $user->setIsVerified(true);
+        $user->setRoles($roles);
+        $user->setPassword($hasher->hashPassword($user, 'TestPassword123!'));
+
+        $em = $this->em();
+        $em->persist($user);
+        $em->flush();
+
+        return $user;
+    }
+
+    private function createCertification(User $user, string $certificateCode, string $type): Certification
+    {
+        $cert = new Certification();
+        $cert->setUser($user);
+        $cert->setIssuedAt(new \DateTimeImmutable());
+        $cert->setCertificateCode($certificateCode);
+        $cert->setType($type);
+
+        $em = $this->em();
+        $em->persist($cert);
+        $em->flush();
+
+        return $cert;
+    }
+}

--- a/tests/Entity/CertificationTest.php
+++ b/tests/Entity/CertificationTest.php
@@ -17,7 +17,9 @@ class CertificationTest extends TestCase
 
         self::assertNull($cert->getId(), 'ID should be null before persistence.');
 
-        self::assertInstanceOf(\DateTimeInterface::class, $cert->getIssuedAt());
+        // Maintenant issuedAt est DateTimeImmutable
+        self::assertInstanceOf(\DateTimeImmutable::class, $cert->getIssuedAt());
+
         self::assertNull($cert->getUser());
         self::assertNull($cert->getCursus());
         self::assertNull($cert->getTheme());
@@ -35,7 +37,8 @@ class CertificationTest extends TestCase
         $theme = new Theme();
         $lesson = new Lesson();
 
-        $issuedAt = new \DateTime('2026-02-24 14:00:00');
+        // DateTimeImmutable (pas DateTime)
+        $issuedAt = new \DateTimeImmutable('2026-02-24 14:00:00');
 
         $cert->setUser($user)
             ->setCursus($cursus)
@@ -63,6 +66,6 @@ class CertificationTest extends TestCase
         $cert->setIssuedAt($issuedAt);
 
         self::assertSame($issuedAt, $cert->getIssuedAt());
-        self::assertInstanceOf(\DateTimeInterface::class, $cert->getIssuedAt());
+        self::assertInstanceOf(\DateTimeImmutable::class, $cert->getIssuedAt());
     }
 }

--- a/tests/Repository/CertificationRepositoryTest.php
+++ b/tests/Repository/CertificationRepositoryTest.php
@@ -25,7 +25,6 @@ class CertificationRepositoryTest extends KernelTestCase
 
         $container = self::getContainer();
 
-        // ✅ reset DB + load fixtures (simple, fiable)
         $container->get(DatabaseToolCollection::class)->get()->loadFixtures([
             ThemeFixtures::class,
             TestUserFixtures::class,
@@ -34,7 +33,6 @@ class CertificationRepositoryTest extends KernelTestCase
         $this->em = $container->get(EntityManagerInterface::class);
         $this->repo = $this->em->getRepository(Certification::class);
 
-        // EM clean
         $this->em->clear();
     }
 
@@ -86,10 +84,15 @@ class CertificationRepositoryTest extends KernelTestCase
         string $code,
         string $type = 'cursus'
     ): Certification {
+        //  Conversion systématique en DateTimeImmutable (ton entité l’exige)
+        $issuedAtImmutable = $issuedAt instanceof \DateTimeImmutable
+            ? $issuedAt
+            : \DateTimeImmutable::createFromInterface($issuedAt);
+
         $cert = new Certification();
         $cert->setUser($user)
             ->setCursus($cursus)
-            ->setIssuedAt($issuedAt)
+            ->setIssuedAt($issuedAtImmutable)
             ->setCertificateCode($code)
             ->setType($type);
 
@@ -103,26 +106,23 @@ class CertificationRepositoryTest extends KernelTestCase
         $user = $this->getFixtureUser();
         $cursus = $this->getAnyCursus();
 
-        $cert = $this->makeCertification($user, $cursus, new \DateTime('2026-01-15'), 'CERT-001');
+        $cert = $this->makeCertification($user, $cursus, new \DateTimeImmutable('2026-01-15'), 'CERT-001');
         $this->em->flush();
 
         $id = $cert->getId();
         self::assertNotNull($id);
 
-        // READ
         $found = $this->repo->find($id);
         self::assertInstanceOf(Certification::class, $found);
         self::assertSame('CERT-001', $found->getCertificateCode());
         self::assertSame($user->getId(), $found->getUser()->getId());
 
-        // UPDATE
         $found->setCertificateCode('CERT-001-UPDATED');
         $this->em->flush();
 
         $reloaded = $this->repo->find($id);
         self::assertSame('CERT-001-UPDATED', $reloaded->getCertificateCode());
 
-        // DELETE
         $this->em->remove($reloaded);
         $this->em->flush();
 
@@ -134,8 +134,8 @@ class CertificationRepositoryTest extends KernelTestCase
         $user = $this->getFixtureUser();
         $cursus = $this->getAnyCursus();
 
-        $this->makeCertification($user, $cursus, new \DateTime('2026-01-01'), 'CERT-OLD');
-        $this->makeCertification($user, $cursus, new \DateTime('2026-02-01'), 'CERT-NEW');
+        $this->makeCertification($user, $cursus, new \DateTimeImmutable('2026-01-01'), 'CERT-OLD');
+        $this->makeCertification($user, $cursus, new \DateTimeImmutable('2026-02-01'), 'CERT-NEW');
         $this->em->flush();
 
         $results = $this->repo->findByUser($user);
@@ -150,8 +150,8 @@ class CertificationRepositoryTest extends KernelTestCase
         $user = $this->getFixtureUser();
         [$cursusA, $cursusB] = $this->getTwoCursus();
 
-        $this->makeCertification($user, $cursusA, new \DateTime('2026-01-10'), 'A-1');
-        $this->makeCertification($user, $cursusB, new \DateTime('2026-01-11'), 'B-1');
+        $this->makeCertification($user, $cursusA, new \DateTimeImmutable('2026-01-10'), 'A-1');
+        $this->makeCertification($user, $cursusB, new \DateTimeImmutable('2026-01-11'), 'B-1');
         $this->em->flush();
 
         $results = $this->repo->findByUserAndCursus($user, $cursusA);
@@ -165,12 +165,12 @@ class CertificationRepositoryTest extends KernelTestCase
         $user = $this->getFixtureUser();
         $cursus = $this->getAnyCursus();
 
-        $this->makeCertification($user, $cursus, new \DateTime('2026-01-05'), 'IN');
-        $this->makeCertification($user, $cursus, new \DateTime('2025-12-20'), 'OUT');
+        $this->makeCertification($user, $cursus, new \DateTimeImmutable('2026-01-05'), 'IN');
+        $this->makeCertification($user, $cursus, new \DateTimeImmutable('2025-12-20'), 'OUT');
         $this->em->flush();
 
-        $from = new \DateTime('2026-01-01 00:00:00');
-        $to   = new \DateTime('2026-01-31 23:59:59');
+        $from = new \DateTimeImmutable('2026-01-01 00:00:00');
+        $to   = new \DateTimeImmutable('2026-01-31 23:59:59');
 
         $results = $this->repo->findByUserAndPeriod($user, $from, $to);
 
@@ -183,9 +183,9 @@ class CertificationRepositoryTest extends KernelTestCase
         $user = $this->getFixtureUser();
         [$cursusA, $cursusB] = $this->getTwoCursus();
 
-        $this->makeCertification($user, $cursusA, new \DateTime('2026-01-01'), 'A-1');
-        $this->makeCertification($user, $cursusA, new \DateTime('2026-01-02'), 'A-2');
-        $this->makeCertification($user, $cursusB, new \DateTime('2026-01-03'), 'B-1');
+        $this->makeCertification($user, $cursusA, new \DateTimeImmutable('2026-01-01'), 'A-1');
+        $this->makeCertification($user, $cursusA, new \DateTimeImmutable('2026-01-02'), 'A-2');
+        $this->makeCertification($user, $cursusB, new \DateTimeImmutable('2026-01-03'), 'B-1');
         $this->em->flush();
 
         self::assertSame(3, $this->repo->countByUser($user));
@@ -198,7 +198,7 @@ class CertificationRepositoryTest extends KernelTestCase
         $user = $this->getFixtureUser();
         $cursus = $this->getAnyCursus();
 
-        $this->makeCertification($user, $cursus, new \DateTime('2026-02-01'), 'CERT-REL', 'cursus');
+        $this->makeCertification($user, $cursus, new \DateTimeImmutable('2026-02-01'), 'CERT-REL', 'cursus');
         $this->em->flush();
 
         $results = $this->repo->findByUserWithTargets($user);
@@ -206,9 +206,7 @@ class CertificationRepositoryTest extends KernelTestCase
         self::assertNotEmpty($results);
         self::assertSame('CERT-REL', $results[0]->getCertificateCode());
 
-        // la méthode fait des leftJoin + addSelect: les relations doivent être disponibles
         self::assertSame($user->getId(), $results[0]->getUser()->getId());
-        // cursus est nullable, mais ici on l’a mis
         self::assertNotNull($results[0]->getCursus());
     }
 
@@ -219,7 +217,8 @@ class CertificationRepositoryTest extends KernelTestCase
         $cert = new Certification();
         $cert->setCertificateCode('X')
             ->setType('cursus')
-            ->setIssuedAt(new \DateTime('2026-01-01'));
+            // DateTimeImmutable (sinon tu as un TypeError avant d’atteindre la contrainte DB)
+            ->setIssuedAt(new \DateTimeImmutable('2026-01-01'));
 
         $this->em->persist($cert);
         $this->em->flush();


### PR DESCRIPTION
Fichiers mise à jour:
- AdminCertificationDownloadTest.php
- CertificationRepository.php
- LessonValidatedService.php
- LessonValidatedServiceTest.php
- entity/Certification.php

Pour le AdminCertificationDownloadTest, il a été vérifié les éléments suivants:
- Happy path : PDF + headers + nom de fichier sanitizé + “PDF ressemble bien à un A4 landscape”
- 404 si ID inexistant + message “Certification introuvable”
- Template Twig : autoescape (pas d’injection HTML via certificateCode / type)