### PR TITLE
admin_theme_index_twig_test

### DIFF
--- a/src/Controller/Admin/AdminThemeController.php
+++ b/src/Controller/Admin/AdminThemeController.php
@@ -20,12 +20,18 @@ class AdminThemeController extends AbstractController
     public function index(Request $request, ThemeRepository $repo): Response
     {
         $q = $request->query->get('q');
-        $status = $request->query->get('status', 'all'); // all|active|archived
+        $status = $request->query->get('status', 'all');
         $sort = $request->query->get('sort', 'created_desc');
 
-        // ✅ Choix A : "actif" = isActive seulement
-        // ✅ + badge "Visible sur le site" calculé en 1 requête
-        $themesWithVisibility = $repo->findAdminThemesWithVisibility($q, $status, $sort, true);
+        $requireCursus = $status === 'active';
+
+        $themesWithVisibility = $repo->findAdminThemesWithVisibility(
+            $q,
+            $status,
+            $sort,
+            true,
+            $requireCursus
+        );
 
         return $this->render('admin/theme/index.html.twig', [
             'themesWithVisibility' => $themesWithVisibility,

--- a/src/Repository/ThemeRepository.php
+++ b/src/Repository/ThemeRepository.php
@@ -139,11 +139,11 @@ class ThemeRepository extends ServiceEntityRepository
         ?string $q = null,
         string $status = 'all',
         string $sort = 'created_desc',
-        bool $onlyActiveCursus = true
+        bool $onlyActiveCursus = true,
+        bool $requireCursus = false
     ): array {
         $qb = $this->createQueryBuilder('t')->distinct();
 
-        // Join cursus (optionnel : pour afficher la liste des cursus sous le thème)
         if ($onlyActiveCursus) {
             $qb->leftJoin('t.cursus', 'c', 'WITH', 'c.isActive = true');
         } else {
@@ -151,7 +151,10 @@ class ThemeRepository extends ServiceEntityRepository
         }
         $qb->addSelect('c');
 
-        // Flag visibilité front : theme actif + EXISTS(cursus actif avec leçon active)
+        if ($requireCursus) {
+            $qb->andWhere('c.id IS NOT NULL');
+        }
+
         $qb->addSelect(
             "CASE WHEN (t.isActive = true AND EXISTS (
                 SELECT 1
@@ -163,7 +166,7 @@ class ThemeRepository extends ServiceEntityRepository
 
         if ($q) {
             $qb->andWhere('LOWER(t.name) LIKE :q')
-               ->setParameter('q', '%'.mb_strtolower(trim($q)).'%');
+            ->setParameter('q', '%'.mb_strtolower(trim($q)).'%');
         }
 
         if ($status === 'active') {

--- a/templates/admin/theme/delete.html.twig
+++ b/templates/admin/theme/delete.html.twig
@@ -5,13 +5,13 @@
   <link rel="stylesheet" href="{{ asset('styles/admin/theme.css') }}">
 {% endblock %}
 
-{% block title %}Admin - Archiver un thème{% endblock %}
+{% block title %}Admin - Désactiver un thème{% endblock %}
 
 {% block dashboard_content %}
 
   <div class="admin-page-header">
     <div>
-      <h1 class="admin-page-title">Archiver un thème</h1>
+      <h1 class="admin-page-title">Désactiver un thème</h1>
       <p class="admin-page-subtitle">
         Ce thème ne sera plus visible côté utilisateurs.
       </p>
@@ -29,20 +29,20 @@
     {% endif %}
 
     <div class="admin-alert">
-      ⚠️ Ce thème ne sera plus visible côté utilisateurs.
+      ⚠️ Ce thème sera désactivé et ne sera plus visible côté utilisateurs.
       <strong>Les cursus, leçons et commandes ne seront pas supprimés.</strong>
     </div>
 
     <form method="post"
-          action="{{ path('admin_theme_disable', { id: theme.id }) }}"
-          class="inline-form"
-          onsubmit="return confirm('Confirmer l\\'archivage ?');">
+      action="{{ path('admin_theme_disable', {'id': theme.id}) }}"
+      class="inline-form"
+      onsubmit="return confirm('Confirmer la désactivation ?');">
 
       {# IMPORTANT : token dédié à l’action disable #}
       <input type="hidden" name="_token" value="{{ csrf_token('theme_disable' ~ theme.id) }}">
 
       <div class="admin-form-actions">
-        <button class="btn btn-danger" type="submit">Confirmer l’archivage</button>
+        <button class="btn btn-danger" type="submit">Confirmer la désactivation</button>
         <a href="{{ path('admin_theme_index') }}" class="btn btn-secondary">Annuler</a>
       </div>
 

--- a/templates/admin/theme/edit.html.twig
+++ b/templates/admin/theme/edit.html.twig
@@ -22,9 +22,23 @@
   {{ form_start(form) }}
 
   <div class="admin-form-grid">
-    <div class="admin-form-field--full">{{ form_row(form.name) }}</div>
-    <div class="admin-form-field--full">{{ form_row(form.description) }}</div>
-    <div class="admin-form-field--full">{{ form_row(form.image) }}</div>
+    <div class="admin-form-field--full">
+      {{ form_label(form.name) }}
+      {{ form_widget(form.name) }}
+      {{ form_errors(form.name) }}
+    </div>
+
+    <div class="admin-form-field--full">
+      {{ form_label(form.description) }}
+      {{ form_widget(form.description) }}
+      {{ form_errors(form.description) }}
+    </div>
+
+    <div class="admin-form-field--full">
+      {{ form_label(form.image) }}
+      {{ form_widget(form.image) }}
+      {{ form_errors(form.image) }}
+    </div>
   </div>
 
   <div class="admin-form-actions">
@@ -32,7 +46,9 @@
     <a href="{{ path('admin_theme_index') }}" class="btn btn-secondary">Annuler</a>
 
     {% if theme.isActive %}
-      <a href="{{ path('admin_theme_delete', {id: theme.id}) }}" class="btn btn-danger">Archiver</a>
+      <a href="{{ path('admin_theme_delete', {'id': theme.id}) }}" class="btn btn-warning">
+        Désactiver
+      </a>
     {% endif %}
   </div>
 

--- a/templates/admin/theme/index.html.twig
+++ b/templates/admin/theme/index.html.twig
@@ -15,24 +15,40 @@
 
 <form method="get" class="admin-filters">
   <div class="admin-filters-row">
-    <input type="search" name="q" value="{{ filters.q ?? '' }}" placeholder="Rechercher un thème…" class="admin-filter-input">
+    <input
+      type="search"
+      name="q"
+      value="{{ filters.q ?? '' }}"
+      placeholder="Rechercher un thème…"
+      class="admin-filter-input"
+    >
 
     <select name="status" class="admin-filter-select">
-      <option value="all"      {{ (filters.status ?? 'all') == 'all' ? 'selected' }}>Tous</option>
-      <option value="active"   {{ (filters.status ?? 'all') == 'active' ? 'selected' }}>Actifs</option>
-      <option value="archived" {{ (filters.status ?? 'all') == 'archived' ? 'selected' }}>Archivés</option>
+      <option value="all" {{ (filters.status ?? 'all') == 'all' ? 'selected' : '' }}>Tous</option>
+      <option value="active" {{ (filters.status ?? 'all') == 'active' ? 'selected' : '' }}>Actifs</option>
+      <option value="archived" {{ (filters.status ?? 'all') == 'archived' ? 'selected' : '' }}>Archivés</option>
     </select>
 
     <select name="sort" class="admin-filter-select">
-      <option value="created_desc" {{ (filters.sort ?? 'created_desc') == 'created_desc' ? 'selected' }}>Plus récents</option>
-      <option value="name_asc"     {{ (filters.sort ?? 'created_desc') == 'name_asc' ? 'selected' }}>Nom A → Z</option>
-      <option value="name_desc"    {{ (filters.sort ?? 'created_desc') == 'name_desc' ? 'selected' }}>Nom Z → A</option>
+      <option value="created_desc" {{ (filters.sort ?? 'created_desc') == 'created_desc' ? 'selected' : '' }}>Plus récents</option>
+      <option value="created_asc" {{ (filters.sort ?? 'created_desc') == 'created_asc' ? 'selected' : '' }}>Plus anciens</option>
+      <option value="name_asc" {{ (filters.sort ?? 'created_desc') == 'name_asc' ? 'selected' : '' }}>Nom A → Z</option>
+      <option value="name_desc" {{ (filters.sort ?? 'created_desc') == 'name_desc' ? 'selected' : '' }}>Nom Z → A</option>
     </select>
 
     <button class="btn" type="submit">Filtrer</button>
     <a class="btn btn-secondary" href="{{ path('admin_theme_index') }}">Réinitialiser</a>
   </div>
 </form>
+
+{% if (filters.status ?? 'all') == 'active' %}
+  <div class="admin-info-message">
+    <p>
+      Affichage des thèmes actifs.
+      Certains thèmes actifs peuvent ne pas être visibles sur le site s’ils n’ont pas encore de cursus actif ou de leçon active.
+    </p>
+  </div>
+{% endif %}
 
 <div class="themes-grid">
   {% for row in themesWithVisibility %}
@@ -43,10 +59,15 @@
 
       {% if theme.image %}
         {% set img = theme.image %}
-        <img src="{{ img starts with 'http' ? img : asset(img) }}" alt="{{ theme.name }}" class="theme-image" loading="lazy">
+        <img
+          src="{{ img starts with 'http' ? img : asset(img) }}"
+          alt="{{ theme.name }}"
+          class="theme-image"
+          loading="lazy"
+        >
       {% endif %}
 
-      <h2>
+      <h2 class="theme-card-title">
         <span>{{ theme.name }}</span>
 
         {% if theme.isActive %}
@@ -56,9 +77,9 @@
         {% endif %}
 
         {% if isVisible %}
-          <span class="badge bg-success">Visible</span>
+          <span class="badge bg-success">Visible sur le site</span>
         {% else %}
-          <span class="badge bg-secondary">Non visible</span>
+          <span class="badge bg-secondary">Non visible sur le site</span>
         {% endif %}
       </h2>
 
@@ -74,20 +95,34 @@
       {% endfor %}
 
       {% if names|length %}
-        <p class="theme-meta"><strong>Cursus :</strong> {{ names|join(', ') }}</p>
+        <p class="theme-meta">
+          <strong>Cursus actifs :</strong> {{ names|join(', ') }}
+        </p>
       {% else %}
         <p class="theme-meta muted">Aucun cursus actif</p>
       {% endif %}
 
       <div class="admin-actions">
-        <a href="{{ path('admin_theme_edit', {'id': theme.id}) }}" class="btn btn-secondary">Modifier</a>
+        <a href="{{ path('admin_theme_edit', {'id': theme.id}) }}" class="btn btn-secondary">
+          Modifier
+        </a>
 
         {% if theme.isActive %}
-          <a href="{{ path('admin_theme_delete', {'id': theme.id}) }}" class="btn btn-archive">Archiver</a>
+          <a href="{{ path('admin_theme_delete', {'id': theme.id}) }}" class="btn btn-warning">
+            Désactiver
+          </a>
         {% else %}
-          <form method="post" action="{{ path('admin_theme_activate', {'id': theme.id}) }}" class="inline-form">
-            <input type="hidden" name="_token" value="{{ csrf_token('theme_activate' ~ theme.id) }}">
-            <button class="btn btn-restore" type="submit">Restaurer</button>
+          <form
+            method="post"
+            action="{{ path('admin_theme_activate', {'id': theme.id}) }}"
+            class="inline-form"
+          >
+            <input
+              type="hidden"
+              name="_token"
+              value="{{ csrf_token('theme_activate' ~ theme.id) }}"
+            >
+            <button class="btn btn-restore" type="submit">Activer</button>
           </form>
         {% endif %}
       </div>

--- a/templates/admin/theme/new.html.twig
+++ b/templates/admin/theme/new.html.twig
@@ -22,9 +22,23 @@
     {{ form_start(form) }}
 
       <div class="admin-form-grid">
-        <div class="admin-form-field--full">{{ form_row(form.name) }}</div>
-        <div class="admin-form-field--full">{{ form_row(form.description) }}</div>
-        <div class="admin-form-field--full">{{ form_row(form.image) }}</div>
+        <div class="admin-form-field--full">
+          {{ form_label(form.name) }}
+          {{ form_widget(form.name) }}
+          {{ form_errors(form.name) }}
+        </div>
+
+        <div class="admin-form-field--full">
+          {{ form_label(form.description) }}
+          {{ form_widget(form.description) }}
+          {{ form_errors(form.description) }}
+        </div>
+
+        <div class="admin-form-field--full">
+          {{ form_label(form.image) }}
+          {{ form_widget(form.image) }}
+          {{ form_errors(form.image) }}
+        </div>
       </div>
 
       <div class="admin-form-actions">

--- a/tests/Controller/Admin/AdminThemeControllerTest.php
+++ b/tests/Controller/Admin/AdminThemeControllerTest.php
@@ -22,7 +22,6 @@ class AdminThemeControllerTest extends WebTestCase
     {
         self::ensureKernelShutdown();
 
-        // ✅ Force HTTPS (security.yaml: requires_channel: https sur ^/admin)
         $this->client = static::createClient([], [
             'HTTPS' => 'on',
             'HTTP_HOST' => 'localhost',
@@ -63,6 +62,7 @@ class AdminThemeControllerTest extends WebTestCase
     {
         $theme = $this->em->getRepository(Theme::class)->findOneBy(['name' => $name]);
         self::assertNotNull($theme, sprintf('Theme "%s" not found in fixtures.', $name));
+
         return $theme;
     }
 
@@ -80,14 +80,12 @@ class AdminThemeControllerTest extends WebTestCase
 
     public function testAdminAreaRequiresAdminRole(): void
     {
-        // Non loggé => redirect login ou 403 (selon config)
         $this->client->request('GET', '/admin/themes');
         self::assertTrue(
             $this->client->getResponse()->isRedirection() ||
             $this->client->getResponse()->getStatusCode() === 403
         );
 
-        // ROLE_USER => 403
         $this->loginAsUser();
         $this->client->request('GET', '/admin/themes');
         self::assertResponseStatusCodeSame(403);
@@ -109,6 +107,61 @@ class AdminThemeControllerTest extends WebTestCase
         self::assertResponseIsSuccessful();
     }
 
+    public function testNewPageDisplaysFormCsrfAndButtons(): void
+    {
+        $this->loginAsAdmin();
+
+        $crawler = $this->client->request('GET', '/admin/themes/new');
+        self::assertResponseIsSuccessful();
+
+        self::assertGreaterThan(0, $crawler->filter('form')->count());
+
+        self::assertGreaterThan(
+            0,
+            $crawler->filter('input[name="theme[_token]"], input[name="_token"]')->count(),
+            'Le champ CSRF du formulaire est introuvable.'
+        );
+
+        self::assertGreaterThan(
+            0,
+            $crawler->filter('button[type="submit"]')->reduce(
+                fn (Crawler $node) => trim($node->text()) === 'Créer'
+            )->count(),
+            'Le bouton "Créer" est introuvable.'
+        );
+
+        self::assertGreaterThan(
+            0,
+            $crawler->filter('a.btn.btn-secondary')->reduce(
+                fn (Crawler $node) =>
+                    trim($node->text()) === 'Annuler'
+                    && $node->attr('href') === '/admin/themes'
+            )->count(),
+            'Le lien "Annuler" vers la liste est introuvable.'
+        );
+    }
+
+    public function testNewPostInvalidDisplaysValidationError(): void
+    {
+        $this->loginAsAdmin();
+
+        $crawler = $this->client->request('GET', '/admin/themes/new');
+        self::assertResponseIsSuccessful();
+
+        $form = $crawler->filter('form')->first()->form();
+        $form['theme[name]'] = '';
+        $form['theme[description]'] = 'Description test';
+        $form['theme[image]'] = '';
+
+        $this->client->submit($form);
+
+        self::assertResponseStatusCodeSame(200);
+        self::assertStringContainsString(
+            'Le nom est obligatoire.',
+            $this->client->getResponse()->getContent()
+        );
+    }
+
     public function testNewPostCreatesThemeAndRedirects(): void
     {
         $this->loginAsAdmin();
@@ -124,9 +177,41 @@ class AdminThemeControllerTest extends WebTestCase
         $this->client->submit($form);
         self::assertResponseRedirects('/admin/themes');
 
+        $this->client->followRedirect();
+        self::assertResponseIsSuccessful();
+
         $created = $this->em->getRepository(Theme::class)->findOneBy(['name' => 'Theme Test Create']);
         self::assertNotNull($created);
         self::assertTrue($created->isActive());
+    }
+
+    public function testNewPostValidRedirectsAndShowsSuccessFlash(): void
+    {
+        $this->loginAsAdmin();
+
+        $crawler = $this->client->request('GET', '/admin/themes/new');
+        self::assertResponseIsSuccessful();
+
+        $form = $crawler->filter('form')->first()->form();
+        $form['theme[name]'] = 'Theme Flash Test';
+        $form['theme[description]'] = 'Description flash';
+        $form['theme[image]'] = '';
+
+        $this->client->submit($form);
+
+        self::assertResponseRedirects('/admin/themes');
+
+        $this->client->followRedirect();
+        self::assertResponseIsSuccessful();
+
+        self::assertSelectorTextContains('.flash-success', 'Thème créé.');
+
+        $this->em->clear();
+        $created = $this->em->getRepository(Theme::class)->findOneBy([
+            'name' => 'Theme Flash Test',
+        ]);
+
+        self::assertNotNull($created);
     }
 
     public function testEditPageIsReachableForAdmin(): void
@@ -179,7 +264,6 @@ class AdminThemeControllerTest extends WebTestCase
         $theme->setIsActive(true);
         $this->em->flush();
 
-        // La page /delete doit contenir le form POST vers /disable avec le token CSRF
         $crawler = $this->client->request('GET', '/admin/themes/'.$theme->getId().'/delete');
         self::assertResponseIsSuccessful();
 
@@ -188,13 +272,11 @@ class AdminThemeControllerTest extends WebTestCase
         $formNode = $crawler->filter(sprintf('form[action="%s"]', $action));
         self::assertGreaterThan(0, $formNode->count(), 'Disable form not found on delete confirmation page.');
 
-        // CSRF invalide => 403
         $badForm = $formNode->first()->form();
         $badForm->setValues(['_token' => 'bad']);
         $this->client->submit($badForm);
         self::assertResponseStatusCodeSame(403);
 
-        // CSRF valide => redirect + isActive=false
         $crawler = $this->client->request('GET', '/admin/themes/'.$theme->getId().'/delete');
         self::assertResponseIsSuccessful();
 
@@ -216,13 +298,11 @@ class AdminThemeControllerTest extends WebTestCase
         $theme->setIsActive(false);
         $this->em->flush();
 
-        // CSRF invalide => 403
         $this->client->request('POST', '/admin/themes/'.$theme->getId().'/activate', [
             '_token' => 'bad',
         ]);
         self::assertResponseStatusCodeSame(403);
 
-        // Token présent sur l'index status=archived (ton Twig affiche le form "Restaurer")
         $crawler = $this->client->request('GET', '/admin/themes?status=archived');
         self::assertResponseIsSuccessful();
 

--- a/tests/Functional/Admin/Theme/AdminThemeDeleteTest.php
+++ b/tests/Functional/Admin/Theme/AdminThemeDeleteTest.php
@@ -1,0 +1,166 @@
+<?php
+
+namespace App\Tests\Functional\Admin\Theme;
+
+use App\Entity\Theme;
+use App\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\DomCrawler\Crawler;
+use Symfony\Component\Routing\RouterInterface;
+
+final class AdminThemeDeleteTest extends WebTestCase
+{
+    private KernelBrowser $client;
+    private EntityManagerInterface $em;
+    private RouterInterface $router;
+
+    private User $admin;
+    private Theme $theme;
+
+    protected function setUp(): void
+    {
+        self::ensureKernelShutdown();
+
+        $this->client = static::createClient();
+        $this->client->followRedirects(true);
+
+        $container = static::getContainer();
+
+        $this->em = $container->get(EntityManagerInterface::class);
+        $this->router = $container->get(RouterInterface::class);
+
+        $this->admin = $this->createAdminUser();
+        $this->theme = $this->createTheme(
+            'Thème suppression test',
+            'Description du thème à désactiver',
+            'images/themes/test/delete.jpg',
+            true
+        );
+
+        $this->em->flush();
+    }
+
+    public function test_delete_confirm_page_displays_confirmation_content(): void
+    {
+        $this->client->loginUser($this->admin);
+
+        $this->client->request('GET', $this->router->generate('admin_theme_delete', [
+            'id' => $this->theme->getId(),
+        ]));
+
+        self::assertResponseIsSuccessful();
+
+        $crawler = $this->client->getCrawler();
+        $content = $this->client->getResponse()->getContent();
+
+        self::assertSelectorTextContains('h1.admin-page-title', 'Désactiver un thème');
+        self::assertSelectorTextContains('.theme-detail-title', $this->theme->getName());
+
+        self::assertIsString($content);
+        self::assertStringContainsString($this->theme->getName(), $content);
+        self::assertStringContainsString((string) $this->theme->getId(), $this->router->generate('admin_theme_disable', [
+            'id' => $this->theme->getId(),
+        ]));
+
+        $desc = $crawler->filter('.theme-detail-desc');
+        self::assertGreaterThan(0, $desc->count());
+        self::assertStringContainsString($this->theme->getDescription(), $desc->text());
+    }
+
+    public function test_confirm_button_posts_to_disable_route_with_csrf_token(): void
+    {
+        $this->client->loginUser($this->admin);
+
+        $this->client->request('GET', $this->router->generate('admin_theme_delete', [
+            'id' => $this->theme->getId(),
+        ]));
+
+        self::assertResponseIsSuccessful();
+
+        $crawler = $this->client->getCrawler();
+        $disableUrl = $this->router->generate('admin_theme_disable', ['id' => $this->theme->getId()]);
+
+        $form = $crawler->filter('form[action="' . $disableUrl . '"][method="post"]');
+        self::assertGreaterThan(
+            0,
+            $form->count(),
+            'Le formulaire de confirmation doit poster vers admin_theme_disable.'
+        );
+
+        $submitButton = $form->filter('button[type="submit"]');
+        self::assertGreaterThan(0, $submitButton->count());
+        self::assertStringContainsString(
+            'Confirmer la désactivation',
+            trim($submitButton->text())
+        );
+
+        $tokenInput = $form->filter('input[name="_token"]');
+        self::assertGreaterThan(0, $tokenInput->count(), 'Le formulaire doit contenir un _token.');
+        self::assertNotNull($tokenInput->attr('value'));
+        self::assertNotSame('', trim((string) $tokenInput->attr('value')), 'Le token CSRF ne doit pas être vide.');
+    }
+
+    public function test_cancel_button_links_back_to_index(): void
+    {
+        $this->client->loginUser($this->admin);
+
+        $this->client->request('GET', $this->router->generate('admin_theme_delete', [
+            'id' => $this->theme->getId(),
+        ]));
+
+        self::assertResponseIsSuccessful();
+
+        $crawler = $this->client->getCrawler();
+        $indexUrl = $this->router->generate('admin_theme_index');
+
+        self::assertGreaterThan(
+            0,
+            $crawler->filter('a[href="' . $indexUrl . '"]')->count(),
+            'Le bouton/lien Annuler doit pointer vers la liste.'
+        );
+
+        $cancelLinks = $crawler->filter('a[href="' . $indexUrl . '"]')->reduce(
+            static fn (Crawler $node): bool => str_contains($node->text(), 'Annuler')
+        );
+
+        self::assertGreaterThan(0, $cancelLinks->count(), 'Un lien "Annuler" vers l’index doit être présent.');
+    }
+
+    private function createAdminUser(): User
+    {
+        $email = 'admin-theme-delete-' . uniqid('', true) . '@example.com';
+
+        $user = (new User())
+            ->setEmail($email)
+            ->setFirstName('Admin')
+            ->setLastName('Theme')
+            ->setIsVerified(true)
+            ->setRoles(['ROLE_ADMIN'])
+            ->setCreatedAt(new \DateTimeImmutable('-1 day'))
+            ->setPassword('test-password-not-used');
+
+        $this->em->persist($user);
+
+        return $user;
+    }
+
+    private function createTheme(
+        string $name,
+        string $description,
+        string $image,
+        bool $isActive
+    ): Theme {
+        $theme = (new Theme())
+            ->setName($name)
+            ->setDescription($description)
+            ->setImage($image)
+            ->setIsActive($isActive)
+            ->setCreatedAt(new \DateTimeImmutable('2024-01-10 10:00:00'));
+
+        $this->em->persist($theme);
+
+        return $theme;
+    }
+}

--- a/tests/Functional/Admin/Theme/AdminThemeEditTest.php
+++ b/tests/Functional/Admin/Theme/AdminThemeEditTest.php
@@ -1,0 +1,179 @@
+<?php
+
+namespace App\Tests\Functional\Admin\Theme;
+
+use App\Entity\Theme;
+use App\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\Routing\RouterInterface;
+
+final class AdminThemeEditTest extends WebTestCase
+{
+    private KernelBrowser $client;
+    private EntityManagerInterface $em;
+    private RouterInterface $router;
+
+    private User $admin;
+    private Theme $theme;
+
+    protected function setUp(): void
+    {
+        self::ensureKernelShutdown();
+
+        $this->client = static::createClient();
+        $this->client->followRedirects(true);
+
+        $container = static::getContainer();
+
+        $this->em = $container->get(EntityManagerInterface::class);
+        $this->router = $container->get(RouterInterface::class);
+
+        $this->admin = $this->createAdminUser();
+        $this->theme = $this->createTheme(
+            'Thème édition test',
+            'Description existante du thème',
+            'images/themes/test/theme.jpg',
+            true
+        );
+
+        $this->em->flush();
+    }
+
+    public function test_edit_page_displays_existing_values(): void
+    {
+        $this->client->loginUser($this->admin);
+
+        $this->client->request('GET', $this->router->generate('admin_theme_edit', [
+            'id' => $this->theme->getId(),
+        ]));
+
+        self::assertResponseIsSuccessful();
+
+        $crawler = $this->client->getCrawler();
+
+        self::assertSelectorTextContains('h1.admin-page-title', 'Modifier : '.$this->theme->getName());
+
+        $nameInput = $crawler->filter('input[name="theme[name]"]');
+        self::assertCount(1, $nameInput);
+        self::assertSame($this->theme->getName(), $nameInput->attr('value'));
+
+        $descriptionTextarea = $crawler->filter('textarea[name="theme[description]"]');
+        self::assertCount(1, $descriptionTextarea);
+        self::assertSame($this->theme->getDescription(), trim($descriptionTextarea->text()));
+
+        $imageInput = $crawler->filter('input[name="theme[image]"]');
+        self::assertCount(1, $imageInput);
+        self::assertSame($this->theme->getImage(), $imageInput->attr('value'));
+    }
+
+    public function test_edit_page_displays_submit_button(): void
+    {
+        $this->client->loginUser($this->admin);
+
+        $this->client->request('GET', $this->router->generate('admin_theme_edit', [
+            'id' => $this->theme->getId(),
+        ]));
+
+        self::assertResponseIsSuccessful();
+
+        $crawler = $this->client->getCrawler();
+
+        $submitButton = $crawler->filter('button[type="submit"]');
+        self::assertGreaterThan(0, $submitButton->count());
+        self::assertStringContainsString('Enregistrer', trim($submitButton->text()));
+    }
+
+    public function test_edit_page_displays_back_link_to_list(): void
+    {
+        $this->client->loginUser($this->admin);
+
+        $this->client->request('GET', $this->router->generate('admin_theme_edit', [
+            'id' => $this->theme->getId(),
+        ]));
+
+        self::assertResponseIsSuccessful();
+
+        $crawler = $this->client->getCrawler();
+        $indexUrl = $this->router->generate('admin_theme_index');
+
+        self::assertGreaterThan(
+            0,
+            $crawler->filter('a[href="'.$indexUrl.'"]')->count(),
+            'Un lien de retour vers la liste des thèmes doit être présent.'
+        );
+    }
+
+    public function test_edit_page_displays_validation_errors(): void
+    {
+        $this->client->loginUser($this->admin);
+
+        $this->client->request('GET', $this->router->generate('admin_theme_edit', [
+            'id' => $this->theme->getId(),
+        ]));
+
+        self::assertResponseIsSuccessful();
+
+        $this->client->submitForm('Enregistrer', [
+            'theme[name]' => '',
+            'theme[description]' => 'Description modifiée',
+            'theme[image]' => 'images/themes/test/new-image.jpg',
+        ]);
+
+        self::assertResponseIsSuccessful();
+
+        $crawler = $this->client->getCrawler();
+        $content = $this->client->getResponse()->getContent();
+
+        self::assertIsString($content);
+        self::assertStringContainsString('Le nom est obligatoire.', $content);
+
+        $nameInput = $crawler->filter('input[name="theme[name]"]');
+        self::assertCount(1, $nameInput);
+
+        $descriptionTextarea = $crawler->filter('textarea[name="theme[description]"]');
+        self::assertCount(1, $descriptionTextarea);
+        self::assertSame('Description modifiée', trim($descriptionTextarea->text()));
+
+        $imageInput = $crawler->filter('input[name="theme[image]"]');
+        self::assertCount(1, $imageInput);
+        self::assertSame('images/themes/test/new-image.jpg', $imageInput->attr('value'));
+    }
+
+    private function createAdminUser(): User
+    {
+        $email = 'admin-theme-edit-'.uniqid('', true).'@example.com';
+
+        $user = (new User())
+            ->setEmail($email)
+            ->setFirstName('Admin')
+            ->setLastName('Theme')
+            ->setIsVerified(true)
+            ->setRoles(['ROLE_ADMIN'])
+            ->setCreatedAt(new \DateTimeImmutable('-1 day'))
+            ->setPassword('test-password-not-used');
+
+        $this->em->persist($user);
+
+        return $user;
+    }
+
+    private function createTheme(
+        string $name,
+        string $description,
+        string $image,
+        bool $isActive
+    ): Theme {
+        $theme = (new Theme())
+            ->setName($name)
+            ->setDescription($description)
+            ->setImage($image)
+            ->setIsActive($isActive)
+            ->setCreatedAt(new \DateTimeImmutable('2024-01-10 10:00:00'));
+
+        $this->em->persist($theme);
+
+        return $theme;
+    }
+}

--- a/tests/Functional/Admin/Theme/AdminThemeIndexTest.php
+++ b/tests/Functional/Admin/Theme/AdminThemeIndexTest.php
@@ -1,0 +1,327 @@
+<?php
+
+namespace App\Tests\Functional\Admin\Theme;
+
+use App\Entity\Theme;
+use App\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\DomCrawler\Crawler;
+use Symfony\Component\Routing\RouterInterface;
+
+final class AdminThemeIndexTest extends WebTestCase
+{
+    private KernelBrowser $client;
+    private EntityManagerInterface $em;
+    private RouterInterface $router;
+
+    private User $admin;
+
+    private Theme $activeTheme;
+    private Theme $archivedTheme;
+    private Theme $activeThemeWithoutCursus;
+
+    protected function setUp(): void
+    {
+        self::ensureKernelShutdown();
+
+        $this->client = static::createClient();
+        $this->client->followRedirects(true);
+
+        $container = static::getContainer();
+
+        $this->em = $container->get(EntityManagerInterface::class);
+        $this->router = $container->get(RouterInterface::class);
+
+        $this->admin = $this->createAdminUser();
+        $this->activeTheme = $this->createTheme(
+            'ZZZ Theme Active Test',
+            true,
+            new \DateTimeImmutable('2024-01-15 10:00:00')
+        );
+        $this->archivedTheme = $this->createTheme(
+            'ZZZ Theme Archived Test',
+            false,
+            new \DateTimeImmutable('2023-01-15 10:00:00')
+        );
+        $this->activeThemeWithoutCursus = $this->createTheme(
+            'ZZZ Theme Sans Cursus Actif',
+            true,
+            new \DateTimeImmutable('2024-06-01 10:00:00')
+        );
+
+        $this->em->flush();
+    }
+
+    public function test_filters_are_prefilled_and_expected_options_exist(): void
+    {
+        $this->client->loginUser($this->admin);
+
+        $this->client->request('GET', '/admin/themes?q=Theme&status=active&sort=name_desc');
+        self::assertResponseIsSuccessful();
+
+        $crawler = $this->client->getCrawler();
+
+        $qInput = $crawler->filter('form.admin-filters input[name="q"]');
+        self::assertCount(1, $qInput);
+        self::assertSame('Theme', $qInput->attr('value'));
+
+        $statusSelect = $crawler->filter('form.admin-filters select[name="status"]');
+        self::assertCount(1, $statusSelect);
+        self::assertSelectHasOption($statusSelect, 'all');
+        self::assertSelectHasOption($statusSelect, 'active');
+        self::assertSelectHasOption($statusSelect, 'archived');
+        self::assertOptionSelected($statusSelect, 'active');
+
+        $sortSelect = $crawler->filter('form.admin-filters select[name="sort"]');
+        self::assertCount(1, $sortSelect);
+        self::assertSelectHasOption($sortSelect, 'created_desc');
+        self::assertSelectHasOption($sortSelect, 'created_asc');
+        self::assertSelectHasOption($sortSelect, 'name_asc');
+        self::assertSelectHasOption($sortSelect, 'name_desc');
+        self::assertOptionSelected($sortSelect, 'name_desc');
+    }
+
+    public function test_search_and_reset_actions_are_visible(): void
+    {
+        $this->client->loginUser($this->admin);
+
+        $this->client->request('GET', '/admin/themes');
+        self::assertResponseIsSuccessful();
+
+        $crawler = $this->client->getCrawler();
+
+        self::assertGreaterThan(
+            0,
+            $crawler->filter('form.admin-filters button[type="submit"]')->count(),
+            'Le bouton de soumission du filtre doit exister.'
+        );
+
+        self::assertStringContainsString(
+            'Filtrer',
+            trim($crawler->filter('form.admin-filters button[type="submit"]')->text()),
+            'Le bouton principal devrait être libellé "Filtrer".'
+        );
+
+        $resetLink = $crawler->filter('form.admin-filters a[href="' . $this->router->generate('admin_theme_index') . '"]');
+        self::assertGreaterThan(0, $resetLink->count(), 'Le lien de reset des filtres doit exister.');
+    }
+
+    public function test_active_badge_is_displayed_clearly(): void
+    {
+        $this->client->loginUser($this->admin);
+
+        $this->client->request('GET', '/admin/themes');
+        self::assertResponseIsSuccessful();
+
+        $crawler = $this->client->getCrawler();
+
+        $activeCard = $this->findThemeCard($crawler, $this->activeTheme->getName());
+        self::assertNotNull($activeCard, 'La carte du thème actif doit être présente.');
+        self::assertStringContainsString('Actif', $activeCard->text());
+
+        $archivedCard = $this->findThemeCard($crawler, $this->archivedTheme->getName());
+        self::assertNotNull($archivedCard, 'La carte du thème archivé doit être présente.');
+        self::assertTrue(
+            str_contains($archivedCard->text(), 'Inactif') || str_contains($archivedCard->text(), 'Archivé'),
+            'Le statut du thème inactif doit être clairement affiché.'
+        );
+    }
+
+    public function test_edit_and_delete_confirm_routes_are_present_for_active_theme(): void
+    {
+        $this->client->loginUser($this->admin);
+
+        $this->client->request('GET', '/admin/themes');
+        self::assertResponseIsSuccessful();
+
+        $crawler = $this->client->getCrawler();
+        $card = $this->findThemeCard($crawler, $this->activeTheme->getName());
+
+        self::assertNotNull($card);
+
+        $editUrl = $this->router->generate('admin_theme_edit', ['id' => $this->activeTheme->getId()]);
+        $deleteUrl = $this->router->generate('admin_theme_delete', ['id' => $this->activeTheme->getId()]);
+
+        self::assertGreaterThan(
+            0,
+            $card->filter('a[href="' . $editUrl . '"]')->count(),
+            'Le bouton Modifier doit pointer vers admin_theme_edit.'
+        );
+
+        self::assertGreaterThan(
+            0,
+            $card->filter('a[href="' . $deleteUrl . '"]')->count(),
+            'Le bouton Désactiver doit pointer vers admin_theme_delete.'
+        );
+    }
+
+    public function test_active_theme_has_disable_confirmation_link(): void
+    {
+        $this->client->loginUser($this->admin);
+
+        $this->client->request('GET', '/admin/themes');
+        self::assertResponseIsSuccessful();
+
+        $crawler = $this->client->getCrawler();
+        $card = $this->findThemeCard($crawler, $this->activeTheme->getName());
+
+        self::assertNotNull($card);
+
+        $deleteUrl = $this->router->generate('admin_theme_delete', ['id' => $this->activeTheme->getId()]);
+
+        self::assertGreaterThan(
+            0,
+            $card->filter('a[href="' . $deleteUrl . '"]')->count(),
+            'Un thème actif doit proposer un lien vers la page de confirmation de désactivation.'
+        );
+
+        self::assertStringContainsString('Désactiver', $card->text());
+    }
+
+    public function test_archived_theme_has_activate_form_with_csrf_token_present(): void
+    {
+        $this->client->loginUser($this->admin);
+
+        $this->client->request('GET', '/admin/themes');
+        self::assertResponseIsSuccessful();
+
+        $crawler = $this->client->getCrawler();
+        $card = $this->findThemeCard($crawler, $this->archivedTheme->getName());
+
+        self::assertNotNull($card);
+
+        $activateUrl = $this->router->generate('admin_theme_activate', ['id' => $this->archivedTheme->getId()]);
+
+        $form = $card->filter('form[action="' . $activateUrl . '"][method="post"]');
+        self::assertGreaterThan(
+            0,
+            $form->count(),
+            'Un thème inactif doit proposer un formulaire POST vers admin_theme_activate.'
+        );
+
+        $tokenInput = $form->filter('input[name="_token"]');
+        self::assertGreaterThan(0, $tokenInput->count(), 'Le formulaire activate doit contenir un _token.');
+        self::assertNotNull($tokenInput->attr('value'));
+        self::assertNotSame('', trim((string) $tokenInput->attr('value')), 'Le token CSRF activate ne doit pas être vide.');
+    }
+
+    public function test_active_theme_should_not_show_activate_button(): void
+    {
+        $this->client->loginUser($this->admin);
+
+        $this->client->request('GET', '/admin/themes');
+        self::assertResponseIsSuccessful();
+
+        $crawler = $this->client->getCrawler();
+        $card = $this->findThemeCard($crawler, $this->activeTheme->getName());
+
+        self::assertNotNull($card);
+
+        self::assertSame(
+            0,
+            $card->filter('button')->reduce(
+                static fn (Crawler $node): bool => str_contains(trim($node->text()), 'Activer')
+            )->count(),
+            'Un thème actif ne doit pas afficher de bouton Activer.'
+        );
+    }
+
+    public function test_archived_theme_should_not_show_disable_confirmation_link(): void
+    {
+        $this->client->loginUser($this->admin);
+
+        $this->client->request('GET', '/admin/themes');
+        self::assertResponseIsSuccessful();
+
+        $crawler = $this->client->getCrawler();
+        $card = $this->findThemeCard($crawler, $this->archivedTheme->getName());
+
+        self::assertNotNull($card);
+
+        $deleteUrl = $this->router->generate('admin_theme_delete', ['id' => $this->archivedTheme->getId()]);
+
+        self::assertSame(
+            0,
+            $card->filter('a[href="' . $deleteUrl . '"]')->count(),
+            'Un thème inactif ne doit pas proposer de lien vers la page de désactivation.'
+        );
+    }
+
+    public function test_active_filter_should_not_show_active_theme_without_active_cursus(): void
+    {
+        $this->client->loginUser($this->admin);
+
+        $this->client->request('GET', '/admin/themes?status=active');
+        self::assertResponseIsSuccessful();
+
+        $content = $this->client->getResponse()->getContent();
+        self::assertIsString($content);
+
+        self::assertStringNotContainsString(
+            $this->activeThemeWithoutCursus->getName(),
+            $content,
+            'Quand status=active et requireCursus est attendu, un thème actif sans cursus actif ne devrait pas apparaître.'
+        );
+    }
+
+    private function createAdminUser(): User
+    {
+        $email = 'admin-theme-index-' . uniqid('', true) . '@example.com';
+
+        $user = (new User())
+            ->setEmail($email)
+            ->setFirstName('Admin')
+            ->setLastName('Theme')
+            ->setIsVerified(true)
+            ->setRoles(['ROLE_ADMIN'])
+            ->setCreatedAt(new \DateTimeImmutable('-1 day'))
+            ->setPassword('test-password-not-used');
+
+        $this->em->persist($user);
+
+        return $user;
+    }
+
+    private function createTheme(string $name, bool $isActive, \DateTimeImmutable $createdAt): Theme
+    {
+        $theme = (new Theme())
+            ->setName($name)
+            ->setDescription('Description de test')
+            ->setImage('images/test.jpg')
+            ->setIsActive($isActive)
+            ->setCreatedAt($createdAt);
+
+        $this->em->persist($theme);
+
+        return $theme;
+    }
+
+    private function findThemeCard(Crawler $crawler, string $themeName): ?Crawler
+    {
+        $cards = $crawler->filter('.theme-card')->reduce(
+            static fn (Crawler $node): bool => str_contains($node->text(), $themeName)
+        );
+
+        return $cards->count() > 0 ? $cards->eq(0) : null;
+    }
+
+    private static function assertSelectHasOption(Crawler $select, string $value): void
+    {
+        self::assertGreaterThan(
+            0,
+            $select->filter(sprintf('option[value="%s"]', $value))->count(),
+            sprintf('L’option "%s" doit être présente.', $value)
+        );
+    }
+
+    private static function assertOptionSelected(Crawler $select, string $value): void
+    {
+        self::assertGreaterThan(
+            0,
+            $select->filter(sprintf('option[value="%s"][selected]', $value))->count(),
+            sprintf('L’option "%s" doit être sélectionnée.', $value)
+        );
+    }
+}


### PR DESCRIPTION
       Fichiers mis à jour:
        modified:   src/Controller/Admin/AdminThemeController.php
        modified:   src/Repository/ThemeRepository.php
        modified:   templates/admin/theme/delete.html.twig
        modified:   templates/admin/theme/edit.html.twig
        modified:   templates/admin/theme/index.html.twig
        modified:   templates/admin/theme/new.html.twig
        modified:   tests/Controller/Admin/AdminThemeControllerTest.php

Nouveaux fichiers testants les twig de Theme du côté Admin
        new file:   tests/Functional/Admin/Theme/AdminThemeDeleteTest.php
        new file:   tests/Functional/Admin/Theme/AdminThemeEditTest.php
        new file:   tests/Functional/Admin/Theme/AdminThemeIndexTest.php

Il y a eu uniformisation des twig, et des tests de mis en place couvrant les points suivants :
admin/theme/index.html.twig (liste)
Variables : themes, filters[q,status,sort]
Filtres/tri UI
 Champs de filtre pré-remplis avec filters.*
 Select status propose all/active/archived
 Select sort propose created_desc|created_asc|name_asc|name_desc
 Bouton “Rechercher” / “Reset filtres” (si prévu)
Table liste
 Colonne “Actif” (isActive) affichée clairement (badge)
 Boutons :
o Edit → route admin_theme_edit
o Delete confirm → admin_theme_delete
o Disable/Activate → POST routes + CSRF
CSRF
 Form disable inclut _token = csrf_token('theme_disable' ~ id) (exact id
attendu : theme_disable{id})
 Form activate inclut _token = csrf_token('theme_activate' ~ id) (tu as
harmonisé sans underscore)
Edge UX
 Si status=active et un thème n’a pas de cursus actif (repo requireCursus), il
ne sort pas : l’UI ne doit pas “surprendre” (message possible)
2) admin/theme/new.html.twig (create)
Variables : form
 form_start(form) affiche bien CSRF (auto)
 Erreurs par champ visibles (form_errors)
 Boutons “Créer” + “Annuler” (retour liste)
 Après submit valide → flash + redirect liste
3) admin/theme/edit.html.twig
Variables : theme, form
 Les valeurs existantes sont affichées
 Erreurs affichées
 Bouton “Sauvegarder”
 Lien retour liste
4) admin/theme/delete.html.twig (confirm)
Variables : theme
 Contenu de confirmation OK (nom/id)
 Bouton “Confirmer désactivation” = POST vers admin_theme_disable + CSRF
 Bouton “Annuler” = lien vers index