### PR TITLE
stats_update

### DIFF
--- a/src/Controller/Admin/AdminController.php
+++ b/src/Controller/Admin/AdminController.php
@@ -2,6 +2,11 @@
 
 namespace App\Controller\Admin;
 
+use App\Repository\UserRepository;
+use App\Repository\CertificationRepository;
+use App\Repository\LessonValidatedRepository;
+use App\Repository\PurchaseItemRepository;
+use App\Repository\PurchaseRepository;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
@@ -17,4 +22,36 @@ class AdminController extends AbstractController
         return $this->render('admin/dashboard.html.twig');
     }
 
+    #[Route('/stats', name: 'stats')]
+    public function stats(
+        UserRepository $userRepo,
+        CertificationRepository $certRepo,
+        LessonValidatedRepository $lessonValidatedRepo,
+        PurchaseItemRepository $purchaseItemRepo,
+        PurchaseRepository $purchaseRepo,
+    ): Response {
+        $mostValidatedLessons = $lessonValidatedRepo->findMostValidatedLessons();
+        $lessonsValidatedCount = $lessonValidatedRepo->count([]);
+
+        $activeUsersCount = $userRepo->count(['archivedAt' => null]);
+
+        $certificationsCount = $certRepo->count([]);     
+    
+        $paidPurchasesCount = $purchaseRepo->countPaidPurchases();
+        $totalSales = $purchaseRepo->getTotalSales();
+
+        $mostPurchasedLessons = $purchaseItemRepo->findMostPurchasedLessons();
+        $mostPurchasedCursus = $purchaseItemRepo->findMostPurchasedCursus();    
+
+        return $this->render('admin/users/stats.html.twig', [
+            'mostValidatedLessons' => $mostValidatedLessons,
+            'lessonsValidatedCount' => $lessonsValidatedCount,
+            'activeUsersCount' => $activeUsersCount,
+            'certificationsCount' => $certificationsCount,
+            'paidPurchasesCount' => $paidPurchasesCount,
+            'totalSales' => $totalSales,
+            'mostPurchasedLessons' => $mostPurchasedLessons,
+            'mostPurchasedCursus' => $mostPurchasedCursus,
+        ]);
+    }
 }

--- a/src/Repository/LessonValidatedRepository.php
+++ b/src/Repository/LessonValidatedRepository.php
@@ -58,4 +58,16 @@ class LessonValidatedRepository extends ServiceEntityRepository
             ->getResult();
     }
 
+    public function findMostValidatedLessons(): array
+    {
+        return $this->createQueryBuilder('lv')
+            ->select('l.title AS lessonTitle, COUNT(lv.id) AS total')
+            ->join('lv.lesson', 'l')
+            ->groupBy('l.id')
+            ->orderBy('total', 'DESC')
+            ->setMaxResults(5)
+            ->getQuery()
+            ->getResult();
+    }
+
 }

--- a/src/Repository/PurchaseItemRepository.php
+++ b/src/Repository/PurchaseItemRepository.php
@@ -72,4 +72,36 @@ class PurchaseItemRepository extends ServiceEntityRepository
             ->getQuery()
             ->getResult();
     }
+
+    public function findMostPurchasedLessons(): array
+    {
+        return $this->createQueryBuilder('pi')
+            ->select('l.title AS lessonTitle, COUNT(pi.id) AS total')
+            ->join('pi.lesson', 'l')
+            ->join('pi.purchase', 'p')
+            ->andWhere('pi.lesson IS NOT NULL')
+            ->andWhere('p.status = :paid')
+            ->setParameter('paid', Purchase::STATUS_PAID)
+            ->groupBy('l.id')
+            ->orderBy('total', 'DESC')
+            ->setMaxResults(5)
+            ->getQuery()
+            ->getResult();
+    }
+
+    public function findMostPurchasedCursus(): array
+    {
+        return $this->createQueryBuilder('pi')
+            ->select('c.name AS cursusName, COUNT(pi.id) AS total')
+            ->join('pi.cursus', 'c')
+            ->join('pi.purchase', 'p')
+            ->andWhere('pi.cursus IS NOT NULL')
+            ->andWhere('p.status = :paid')
+            ->setParameter('paid', Purchase::STATUS_PAID)
+            ->groupBy('c.id')
+            ->orderBy('total', 'DESC')
+            ->setMaxResults(5)
+            ->getQuery()
+            ->getResult();
+    }
 }

--- a/src/Repository/PurchaseRepository.php
+++ b/src/Repository/PurchaseRepository.php
@@ -204,4 +204,24 @@ class PurchaseRepository extends ServiceEntityRepository
             ->getQuery()
             ->getOneOrNullResult();
     }
+
+    public function countPaidPurchases(): int
+    {
+        return (int) $this->createQueryBuilder('p')
+            ->select('COUNT(p.id)')
+            ->andWhere('p.status = :paid')
+            ->setParameter('paid', Purchase::STATUS_PAID)
+            ->getQuery()
+            ->getSingleScalarResult();
+    }
+
+    public function getTotalSales(): float
+    {
+        return (float) $this->createQueryBuilder('p')
+            ->select('COALESCE(SUM(p.total), 0)')
+            ->andWhere('p.status = :paid')
+            ->setParameter('paid', Purchase::STATUS_PAID)
+            ->getQuery()
+            ->getSingleScalarResult();
+    }
 }

--- a/templates/admin/dashboard.html.twig
+++ b/templates/admin/dashboard.html.twig
@@ -32,8 +32,8 @@
           Liste des utilisateurs actifs
         </a>
 
-        <a href="{{ path('admin_users_index', { action: 'edit', status: 'active' }) }}" data-no-card-click>
-          Comptes & suivi pédagogique
+        <a href="{{ path('admin_stats') }}" data-no-card-click>
+          Statistiques & suivi pédagogique
         </a>
       </div>
 

--- a/templates/admin/users/show.html.twig
+++ b/templates/admin/users/show.html.twig
@@ -15,7 +15,7 @@
     <div class="admin-page-header">
       <div>
         <h1 class="admin-page-title">Fiche client : {{ user.firstName }} {{ user.lastName }} </h1>
-        <p class="admin-page-subtitle">Vous consultez actuellement les informations de {{ user.firstName }}, 
+        <p class="admin-page-subtitle">Vous consultez actuellement les informations de {{ user.firstName }},
         ainsi que son activité sur la plateforme.
       </div>
 

--- a/templates/admin/users/stats.html.twig
+++ b/templates/admin/users/stats.html.twig
@@ -1,0 +1,142 @@
+{% extends 'dashboard/admin/_base.html.twig' %}
+
+{% block stylesheets %}
+  {{ parent() }}
+  <link rel="stylesheet" href="{{ asset('styles/admin/users.css') }}">
+{% endblock %}
+
+{% block title %}Admin - Statistiques et suivi pédagogique{% endblock %}
+
+{% block robots %}noindex,nofollow{% endblock %}
+
+{% block dashboard_content %}
+<div class="admin-users-edit">
+  <div class="admin-page-header">
+    <div>
+      <h1 class="admin-page-title">Statistiques et suivi pédagogique</h1>
+      <p class="admin-page-subtitle">
+        Cette page présente les principaux indicateurs commerciaux et pédagogiques de la plateforme.
+      </p>
+    </div>
+  </div>
+
+  <div class="dashboard-card card-white admin-section">
+    <h2 class="admin-section-title">La plateforme en quelques chiffres</h2>
+
+    <div class="admin-stats-grid">
+      <div class="admin-stat-card">
+        <span class="admin-stat-label">Utilisateurs actifs</span>
+        <strong class="admin-stat-value">{{ activeUsersCount }}</strong>
+      </div>
+
+      <div class="admin-stat-card">
+        <span class="admin-stat-label">Commandes payées</span>
+        <strong class="admin-stat-value">{{ paidPurchasesCount }}</strong>
+      </div>
+
+      <div class="admin-stat-card">
+        <span class="admin-stat-label">Total des ventes</span>
+        <strong class="admin-stat-value">{{ totalSales|number_format(2, ',', ' ') }} €</strong>
+      </div>
+
+      <div class="admin-stat-card">
+        <span class="admin-stat-label">Certificats délivrés</span>
+        <strong class="admin-stat-value">{{ certificationsCount }}</strong>
+      </div>
+    </div>
+  </div>
+
+  <div class="dashboard-card card-white admin-section">
+    <h2 class="admin-section-title">Suivi commercial</h2>
+
+    <h3 class="admin-subtitle">Cursus les plus achetés</h3>
+
+    {% if mostPurchasedCursus is empty %}
+      <p class="admin-empty">Aucun cursus acheté pour le moment.</p>
+    {% else %}
+      <table class="admin-table">
+        <thead>
+          <tr>
+            <th>Cursus</th>
+            <th>Nombre d’achats</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for cursus in mostPurchasedCursus %}
+            <tr>
+              <td>{{ cursus.cursusName }}</td>
+              <td>{{ cursus.total }}</td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    {% endif %}
+
+    <h3 class="admin-subtitle admin-subtitle--spaced">Leçons les plus achetées</h3>
+
+    {% if mostPurchasedLessons is empty %}
+      <p class="admin-empty">Aucune leçon achetée pour le moment.</p>
+    {% else %}
+      <table class="admin-table">
+        <thead>
+          <tr>
+            <th>Leçon</th>
+            <th>Nombre d’achats</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for lesson in mostPurchasedLessons %}
+            <tr>
+              <td>{{ lesson.lessonTitle }}</td>
+              <td>{{ lesson.total }}</td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    {% endif %}
+  </div>
+
+  <div class="dashboard-card card-white admin-section">
+    <h2 class="admin-section-title">Suivi pédagogique</h2>
+
+    <div class="admin-stats-grid">
+      <div class="admin-stat-card">
+        <span class="admin-stat-label">Validations de leçons</span>
+        <strong class="admin-stat-value">{{ lessonsValidatedCount }}</strong>
+      </div>
+
+      <div class="admin-stat-card">
+        <span class="admin-stat-label">Certificats délivrés</span>
+        <strong class="admin-stat-value">{{ certificationsCount }}</strong>
+      </div>
+    </div>
+
+    <h3 class="admin-subtitle admin-subtitle--spaced">Leçons les plus validées</h3>
+
+    {% if mostValidatedLessons is empty %}
+      <p class="admin-empty">Aucune leçon validée pour le moment.</p>
+    {% else %}
+      <table class="admin-table">
+        <thead>
+          <tr>
+            <th>Leçon</th>
+            <th>Nombre de validations</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for lesson in mostValidatedLessons %}
+            <tr>
+              <td>{{ lesson.lessonTitle }}</td>
+              <td>{{ lesson.total }}</td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    {% endif %}
+  </div>
+
+  <a href="{{ path('admin_dashboard') }}" class="btn btn-secondary">
+    ← Retour à l'espace administrateur
+  </a>
+</div>
+{% endblock %}


### PR DESCRIPTION
Màj AdminController : ajout d'une route pour les stats. 

Màj du template admin dashboard, pour un nouveau lien  pour partie statistiques et suivi pédagogique

Màj du PurchaseItemRepository :
- findMostPurchasedLessons
- findMostPurchasedCursus

Màj PurchaseRepository:
- countPaidPurchases
- getTotalSales

Màj LessonValidatedRepository:
- findMostValidatedLessons

Création d'un nouveau twig pour les stats

Màj twig admin/users

Désormais on a vraiment une page pour voir l'évolution en chiffre des formations qui fonctionnent le mieux, le nombre de vente, utilisateurs actifs etc. c'est beaucoup mieux côté admin. Ils pourront faire un vrai suivi.